### PR TITLE
Make bodyParser.toJSON use .json based on the content type

### DIFF
--- a/src/server/body-parser.ts
+++ b/src/server/body-parser.ts
@@ -42,6 +42,10 @@ export let bodyParser = {
    * }
    */
   async toJSON(request: Request): Promise<unknown> {
+    if (request.headers.get("Content-Type") === "application/json") {
+      return request.json();
+    }
+
     let params = await this.toSearchParams(request);
     return Object.fromEntries(params.entries()) as unknown;
   },

--- a/test/server/body-parser.test.ts
+++ b/test/server/body-parser.test.ts
@@ -40,4 +40,18 @@ describe("Body Parser", () => {
       expect(body).toEqual({ a: "1", b: "2" });
     });
   });
+
+  describe(bodyParser.toJSON, () => {
+    test("should be able to parse stringify JSON body when content type is JSON", async () => {
+      let request = new Request("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ a: 1, b: 2 }),
+      });
+
+      let body = (await bodyParser.toJSON(request)) as { a: 1; b: 2 };
+
+      expect(body).toEqual({ a: 1, b: 2 });
+    });
+  });
 });


### PR DESCRIPTION
Hello there,

I was working with some API endpoint in Remix and realized afterwards that the `bodyParser` didn't handle some payload properly.

This PR adds support for JSON body whenever the `Content-Type` header is specify to `application/json`.

Thanks for the amazing work 🙏