### PR TITLE
Add render prop support to ClientOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install remix-utils remix @remix-run/node @remix-run/react react
 
 The ClientOnly component lets you render the children element only on the client-side, avoiding rendering it the server-side.
 
-You can, optionally, provide a fallback component to be used on SSR.
+You can provide a fallback component to be used on SSR, and while optional, it's highly recommended to provide one to avoid content layout shift issues.
 
 ```tsx
 import { ClientOnly } from "remix-utils";
@@ -22,7 +22,7 @@ import { ClientOnly } from "remix-utils";
 export default function View() {
   return (
     <ClientOnly fallback={<SimplerStaticVersion />}>
-      <ComplexComponentNeedingBrowserEnvironment />
+      {() => <ComplexComponentNeedingBrowserEnvironment />}
     </ClientOnly>
   );
 }

--- a/src/react/client-only.tsx
+++ b/src/react/client-only.tsx
@@ -38,6 +38,12 @@ type Props =
  * ```
  */
 export function ClientOnly({ children, fallback = null }: Props) {
+  if (typeof children !== "function") {
+    console.warn(
+      "[remix-utils] ClientOnly: Pass a function as children to avoid issues with client-only imported components"
+    );
+  }
+
   return useHydrated() ? (
     <>{typeof children === "function" ? children() : children}</>
   ) : (

--- a/src/react/client-only.tsx
+++ b/src/react/client-only.tsx
@@ -1,10 +1,26 @@
 import { ReactNode } from "react";
 import { useHydrated } from "./use-hydrated";
 
-type Props = {
+/**
+ * @deprecated Pass a function as children to avoid issues with client only
+ * imported components
+ */
+type DeprecatedProps = {
   children: ReactNode;
   fallback?: ReactNode;
 };
+
+type Props =
+  | DeprecatedProps
+  | {
+      /**
+       * You are encouraged to add a fallback that is the same dimensions
+       * as the client rendered children. This will avoid content layout
+       * shift which is disgusting
+       */
+      children: () => ReactNode;
+      fallback?: ReactNode;
+    };
 
 /**
  * Render the children only after the JS has loaded client-side. Use an optional
@@ -16,11 +32,15 @@ type Props = {
  * ```tsx
  * return (
  *   <ClientOnly fallback={<FakeChart />}>
- *     <Chart />
+ *     {() => <Chart />}
  *   </ClientOnly>
  * );
  * ```
  */
 export function ClientOnly({ children, fallback = null }: Props) {
-  return useHydrated() ? <>{children}</> : <>{fallback}</>;
+  return useHydrated() ? (
+    <>{typeof children === "function" ? children() : children}</>
+  ) : (
+    <>{fallback}</>
+  );
 }


### PR DESCRIPTION
Deprecates non-render prop usage of `children` to avoid issues with using client-only imports on the server.

For example, this will cause a problem on the server due to how Remix replaces client only imports with an empty module:

```ts
import ClientOnly from "remix-utils";
import Chart from "Chart.client.tsx";

function FakeChart() { ... }

function ClientChart() {
  return (
    <ClientOnly fallback={<FakeChart />}>
      <Chart />
    </ClientOnly>
  );
}
```

Will give the error:
```sh
Error: Element type is invalid: expected a string (for built-in components) or a class/function...
```

Moving to a render function sidesteps the issue by delaying the call to `jsx` or `createElement` until the hydrated component runs on the client:

```ts
import ClientOnly from "remix-utils";
import Chart from "Chart.client.tsx";

function FakeChart() { ... }

function ClientChart() {
  return (
    <ClientOnly fallback={<FakeChart />}>
      {() => <Chart />}
    </ClientOnly>
  );
}
```