### PR TITLE
feat: add StructuredData handler to support inserting "application/ld+json" scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,82 @@ Now, any script you defined in the ScriptsFunction will be added to the HTML tog
 
 > Tip: You could use it together with useShouldHydrate to disable Remix scripts in certain routes but still load scripts for analytics or small features that need JS but don't need the full app JS to be enabled.
 
+
+### StructuredData
+
+If you need to include structured data (JSON-LD) scripts on certain routes, you can use the `StructuredData` component together with the `StructuredDataFunction` type.
+
+In the route you want to include the structured data, add a `handle` export with a `structuredData` method, this method should implement the `StructuredDataFunction` type.
+
+```ts
+import type { WithContext, BlogPosting } from 'schema-dts';
+
+// export the handle with the correct type:
+export let handle: HandleStructuredData = {
+  structuredData: (data: LoaderData) => {
+    try {
+      let { post } = data;
+      
+      let postSchemaScript: WithContext<BlogPosting> = {
+        '@context': 'https://schema.org',
+        '@type': 'BlogPosting',
+        datePublished: post.published,
+        mainEntityOfPage: {
+          '@type': 'WebPage',
+          '@id': post.postUrl,
+        },
+        image: post.featured_image,
+        author: {
+          '@type': 'Person',
+          name: post.authorName,
+        },
+      };
+
+      return [{
+        key: 'postSchemaScript',
+        type: 'application/ld+json',
+        data: postSchemaScript,
+      }];
+    } catch (e: any) {
+      console.error(e);
+      return [];
+    }
+  },
+};
+```
+
+Then, in the root route, add the `StructuredData` component together with the Remix's Scripts component, usually inside a Document component.
+
+```tsx
+import { Links, LiveReload, Meta, Scripts, ScrollRestoration } from "remix";
+import { StructuredData } from "remix-utils";
+
+type Props = { children: React.ReactNode; title?: string };
+
+export function Document({ children, title }: Props) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        {title ? <title>{title}</title> : null}
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        {children}
+        <ScrollRestoration />
+        <Scripts />
+        <StructuredData />
+        {process.env.NODE_ENV === "development" && <LiveReload />}
+      </body>
+    </html>
+  );
+}
+```
+
+Now, any structured data you defined in the StructuredDataFunction will be added to the HTML, in the body.
+
 ### Outlet & useParentData
 
 > This feature is now built-in into Remix as `Outlet` & `useOutletContext` so it's marked as deprecated here. The feature will be removed in v3 of Remix Utils.

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "prettier": "^2.5.1",
         "react": "^17.0.2",
         "react-router-dom": "^6.0.0-beta.6",
+        "schema-dts": "^1.1.0",
         "ts-node": "^10.4.0",
         "typescript": "^4.2.4"
       },
@@ -18179,6 +18180,15 @@
         "object-assign": "^4.1.1"
       }
     },
+    "node_modules/schema-dts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-1.1.0.tgz",
+      "integrity": "sha512-vdmbs/5ycj4zyKpZIDqTcy+IZi4s7c38RVAYuDmRi7zgxUT8wRWPMLzg0jr7FjdVunYu9yZ00F3+XcZTTFcTOQ==",
+      "dev": true,
+      "peerDependencies": {
+        "typescript": ">=4.1.0"
+      }
+    },
     "node_modules/schema-utils": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -34450,6 +34460,13 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
       }
+    },
+    "schema-dts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-1.1.0.tgz",
+      "integrity": "sha512-vdmbs/5ycj4zyKpZIDqTcy+IZi4s7c38RVAYuDmRi7zgxUT8wRWPMLzg0jr7FjdVunYu9yZ00F3+XcZTTFcTOQ==",
+      "dev": true,
+      "requires": {}
     },
     "schema-utils": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "prettier": "^2.5.1",
     "react": "^17.0.2",
     "react-router-dom": "^6.0.0-beta.6",
+    "schema-dts": "^1.1.0",
     "ts-node": "^10.4.0",
     "typescript": "^4.2.4"
   },

--- a/src/react.ts
+++ b/src/react.ts
@@ -8,3 +8,4 @@ export * from "./react/use-hydrated";
 export * from "./react/use-revalidate";
 export * from "./react/use-route-data";
 export * from "./react/use-should-hydrate";
+export * from "./react/structured-data";

--- a/src/react/structured-data.tsx
+++ b/src/react/structured-data.tsx
@@ -1,0 +1,74 @@
+import { useMatches } from "@remix-run/react";
+import type { Thing, WithContext } from "schema-dts";
+
+export type StructuredDataDescriptor = {
+  key: string;
+  data: WithContext<Thing>;
+};
+
+/**
+ * A convenience type for `export let handle =` to ensure the correct `handle` structure is used.
+ *
+ * @example
+ * // This route uses the data to render structured data (e.g. BreadcrumbList and BlogPosting)
+ * export let handle: HandleStructuredData<LoaderData> = {
+ *    structuredData: (data) => {
+ *       return [{...}]
+ *    },
+ * };
+ */
+export type HandleStructuredData<T = unknown> = {
+  structuredData: StructuredDataFunction<T>;
+};
+
+function isHandleStructuredData(
+  handle: unknown
+): handle is HandleStructuredData {
+  return (
+    (handle as HandleStructuredData).structuredData !== undefined &&
+    typeof (handle as HandleStructuredData).structuredData === "function"
+  );
+}
+
+export type StructuredDataFunction<T = unknown> = (
+  data: T
+) => StructuredDataDescriptor[];
+
+/**
+ * Render script tags for structured data (https://developers.google.com/search/docs/advanced/structured-data/intro-structured-data)
+ * @example
+ * // This route uses the data to render structured data (e.g. BreadcrumbList and BlogPosting)
+ * export const handle = {
+ *    structuredData: (data: LoaderData) => {
+ *       return postToStructuredData(data.post);
+ *    },
+ * };
+ */
+export function StructuredData() {
+  const matches = useMatches();
+  const structuredData = matches.flatMap((match) => {
+    const { handle, data } = match;
+
+    if (isHandleStructuredData(handle)) {
+      return handle.structuredData(data);
+    }
+
+    return [];
+  });
+
+  return (
+    <>
+      {structuredData.map(({ key, data }) => {
+        return (
+          <script
+            key={key}
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify(data),
+            }}
+          />
+        );
+      })}
+    </>
+  );
+}


### PR DESCRIPTION
This PR adds a new `<StructuredData />` handler, specifically for "application/ld+json" scripts (https://developers.google.com/search/docs/advanced/structured-data/intro-structured-data).

There are a couple new opinions in this PR to improve typings, that we can discuss (I'll comment in the relevant code sections).

I've also add `schema-dts` as a dev dependency, in order to give StructuredData really good types. Let me know if you'd prefer to leave these types to user to define.