### PR TITLE
Allow broader react version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "@remix-run/react": "^1.1.1",
     "@remix-run/server-runtime": "^1.1.1",
-    "react": "^17.0.2"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",


### PR DESCRIPTION
Currently consumers receive peer dep warning when trying to install this package with a version that's not react 17.0.2

As far as I can tell, it only requires hook support, so adjusted the peerDep range to allow hook compatible versions.