### PR TITLE
Accept FormData in verifyAuthenticityToken alongside a Request

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "npm run build:browser && npm run build:main",
     "build:browser": "tsc --project tsconfig.json --module ESNext --outDir ./browser",
     "build:main": "tsc --project tsconfig.json --module CommonJS --outDir ./build",
+    "prepare": "npm run build:main",
     "typecheck": "tsc --project tsconfig.json --noEmit",
     "lint": "eslint --ext .ts,.tsx src/",
     "test": "jest --config=config/jest.config.ts --passWithNoTests"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "build": "npm run build:browser && npm run build:main",
     "build:browser": "tsc --project tsconfig.json --module ESNext --outDir ./browser",
     "build:main": "tsc --project tsconfig.json --module CommonJS --outDir ./build",
-    "prepare": "npm run build:main",
     "typecheck": "tsc --project tsconfig.json --noEmit",
     "lint": "eslint --ext .ts,.tsx src/",
     "test": "jest --config=config/jest.config.ts --passWithNoTests"

--- a/src/server/csrf.ts
+++ b/src/server/csrf.ts
@@ -54,7 +54,7 @@ export async function verifyAuthenticityToken(
   // We clone the request to ensure we don't modify the original request.
   // This allow us to parse the body of the request and let the original request
   // still be used and parsed without errors.
-  let formData = (data instanceof FormData && data) || await data.clone().formData();
+  let formData = data instanceof FormData ? data : await data.clone().formData();
 
   // if the session doesn't have a csrf token, throw an error
   if (!session.has(sessionKey)) {

--- a/src/server/csrf.ts
+++ b/src/server/csrf.ts
@@ -33,13 +33,20 @@ export function createAuthenticityToken(session: Session, sessionKey = "csrf") {
  *   await verifyAuthenticityToken(request, session, "csrfToken");
  *   // the request is authenticated and you can do anything here
  * }
+ * @example
+ * let action: ActionFunction = async ({ request }) => {
+ *   let session = await getSession(request.headers.get("Cookie"));
+ *   let formData = await unstable_parseMultipartFormData(request, uploadHandler);
+ *   await verifyAuthenticityToken(formData, session);
+ *   // the request is authenticated and you can do anything here
+ * }
  */
 export async function verifyAuthenticityToken(
-  request: Request,
+  data: Request | FormData,
   session: Session,
   sessionKey = "csrf"
 ) {
-  if (request.bodyUsed) {
+  if (data instanceof Request && data.bodyUsed) {
     throw new Error(
       "The body of the request was read before calling verifyAuthenticityToken. Ensure you clone it before reading it."
     );
@@ -47,7 +54,7 @@ export async function verifyAuthenticityToken(
   // We clone the request to ensure we don't modify the original request.
   // This allow us to parse the body of the request and let the original request
   // still be used and parsed without errors.
-  let formData = await request.clone().formData();
+  let formData = (data instanceof FormData && data) || await data.clone().formData();
 
   // if the session doesn't have a csrf token, throw an error
   if (!session.has(sessionKey)) {

--- a/test/server/csrf.test.ts
+++ b/test/server/csrf.test.ts
@@ -103,5 +103,26 @@ describe("CSRF Server", () => {
         );
       }
     });
+
+    test.each([
+      [undefined, "csrf"],
+      ["xsrf", "xsrf"],
+    ])("should validate request if session and body csrf match", async (sessionKey, expected) => {
+      let session = await sessionStorage.getSession();
+      session.set(expected, "token");
+
+      let cookie = await sessionStorage.commitSession(session);
+
+      let formData = new FormData();
+      formData.set(expected, "token");
+
+      let request = new Request("/", {
+        method: "POST",
+        headers: { cookie },
+        body: formData,
+      });
+
+      await verifyAuthenticityToken(request, session, sessionKey);
+    });
   });
 });

--- a/test/server/csrf.test.ts
+++ b/test/server/csrf.test.ts
@@ -1,4 +1,4 @@
-import { createCookieSessionStorage } from "@remix-run/node";
+import { createCookieSessionStorage, unstable_parseMultipartFormData, UploadHandler } from "@remix-run/node";
 import { createAuthenticityToken, verifyAuthenticityToken } from "../../src/";
 
 describe("CSRF Server", () => {
@@ -123,6 +123,36 @@ describe("CSRF Server", () => {
       });
 
       await verifyAuthenticityToken(request, session, sessionKey);
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    test("should validate request with File if session and body csrf match", async () => {
+      jest.spyOn(console, 'warn');
+      const uploadHandler = <UploadHandler>(part => Promise.resolve(`${part.filename} contents`));
+
+      let session = await sessionStorage.getSession();
+      session.set("csrf", "token");
+
+      let cookie = await sessionStorage.commitSession(session);
+
+      let formData = new FormData();
+      formData.set("csrf", "token");
+      formData.set("upload", new Blob(["blob"]), "blob.ext");
+
+      let request = new Request("/", {
+        method: "POST",
+        headers: { cookie },
+        body: formData,
+      });
+
+      await verifyAuthenticityToken(
+        await unstable_parseMultipartFormData(request, uploadHandler),
+        session);
+
+      // Tried to parse multipart file upload for field "upload" but no uploadHandler was provided.
+      // Read more here: https://remix.run/api/remix#parseMultipartFormData-node
+      expect(console.warn).toHaveBeenCalledTimes(0);
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/sergiodxa/remix-utils/issues/46 by teaching `verifyAuthenticityToken()` to accept a `FormData` as well as a `Request`. This allows passing in a pre-parsed body, e.g.

```ts
await verifyAuthenticityToken(
  await unstable_parseMultipartFormData(request, uploadHandler),
  session);
```
