### PR TITLE
Only create a new authenticity token if not already in the session

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 export * from "./server/cors";
 export * from "./server/csrf";
-export * from "./server/get-client-id-address";
+export * from "./server/get-client-ip-address";
 export * from "./server/get-client-locales";
 export * from "./server/is-prefetch";
 export * from "./server/responses";

--- a/src/server/csrf.ts
+++ b/src/server/csrf.ts
@@ -14,7 +14,9 @@ import { unprocessableEntity } from "./responses";
  * return json({ ...otherData, csrf: token }); // return the token in the data
  */
 export function createAuthenticityToken(session: Session, sessionKey = "csrf") {
-  let token = uuid();
+  let token = session.get(sessionKey)
+  if (token) return token
+  token = uuid();
   session.set(sessionKey, token);
   return token;
 }


### PR DESCRIPTION
Updated `createAuthenticityToken` to only generate a new token if one is not already in the session and added a new test for that case - that test and all existing tests are passing. 

The `./server/get-client-ip-address` export in `server.ts` had a typo which was breaking the tests so that's been changed as well. 

There are some formatting updates in the `csrf.test.ts` file to please eslint. 