### PR TITLE
Remove Promise return type from typedSession.get

### DIFF
--- a/src/server/typed-session.ts
+++ b/src/server/typed-session.ts
@@ -37,7 +37,7 @@ export interface TypedSession<Schema extends z.ZodTypeAny> {
    */
   get<Key extends keyof z.infer<Schema>>(
     key: Key
-  ): Promise<z.infer<Schema>[Key] | null>;
+  ): z.infer<Schema>[Key] | null;
   /**
    * Sets a value in the session for the given `name`.
    */


### PR DESCRIPTION
`typedSession.get` appears to have a `Promise` return type when it actually isn't a `Promise`.