### PR TITLE
Remove correct event in useEventSource

### DIFF
--- a/src/react/use-event-source.tsx
+++ b/src/react/use-event-source.tsx
@@ -26,7 +26,7 @@ export function useEventSource(
     }
 
     return () => {
-      eventSource.removeEventListener("message", handler);
+      eventSource.removeEventListener(event ?? "message", handler);
       eventSource.close();
     };
   }, [url, event, init]);


### PR DESCRIPTION
Small fix for the useEventSource hook: In the clean up function from the useEffect eventSource.removeEventListener is called with the default event "message". But if the user is using a different event name, it is not removed. So using the same parameter as in the addEventListener  call solves that issue. 
