### PR TITLE
rollingCookies override destroySession

### DIFF
--- a/src/server/rolling-cookie.ts
+++ b/src/server/rolling-cookie.ts
@@ -8,7 +8,7 @@ export async function rollingCookie<Schema extends z.ZodTypeAny>(
   responseHeaders: Headers
 ) {
   let value = await cookie.parse(responseHeaders.get("Set-Cookie"));
-  if (value) return;
+  if (value !== null) return;
   value = await cookie.parse(request.headers.get("Cookie"));
   if (!value) return;
   responseHeaders.append("Set-Cookie", await cookie.serialize(value));


### PR DESCRIPTION
when you use `destroySession` the `Set-Cookie` header is assigned an empty string. actually the `rollingCookies` function checks if the header value is Falsy, and if it is it takes the session from the request and commits it which makes it impossible to logout.

The function should check if the value is strictly null instead of Falsy to avoid overwriting the `Set-Cookie` header when trying to logout.
