### PR TITLE
Add DigitalOcean IP header and fix case where IPs didn't have a space after comma

### DIFF
--- a/src/server/get-client-ip-address.ts
+++ b/src/server/get-client-ip-address.ts
@@ -17,6 +17,7 @@ const headerNames = Object.freeze([
   "X-Forwarded",
   "Forwarded-For",
   "Forwarded",
+  "DO-Connecting-IP", /** Digital ocean app platform */
 ] as const);
 
 /**
@@ -36,6 +37,7 @@ const headerNames = Object.freeze([
  * - X-Forwarded
  * - Forwarded-For
  * - Forwarded
+ * - DO-Connecting-IP
  *
  * If the IP address is valid, it will be returned. Otherwise, null will be
  * returned.
@@ -56,8 +58,8 @@ export function getClientIPAddress(
       if (headerName === "Forwarded") {
         return parseForwardedHeader(value);
       }
-      if (!value?.includes(", ")) return value;
-      return value.split(", ");
+      if (!value?.includes(",")) return value;
+      return value.split(",").map(ip => ip.trim());
     })
     .find((ip) => {
       if (ip === null) return false;


### PR DESCRIPTION
Adding Digital Ocean specific headers to the  function. Also, in some cases (DO) the  header included multiple IPs in a comma separated list (without spaces) so I updated the split to be just a comma and then trim out empty spaces that may exist