### PR TITLE
Add component to treat anchors as client side navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1459,6 +1459,37 @@ export default function Component() {
 }
 ```
 
+### Treat internal `<a href>` as `<Link>` for client-side navigation
+
+When using Remix, you can use the `<Link>` component to navigate between pages. However, if you have a `<a href>` that links to a page in your app, it will cause a full page refresh. This can be what you want, but sometimes you want to use client-side navigation here instead.
+
+You can opt into this behaviour by wrapping a portion of your app in `<TreatAnchorsAsClientSideNavigation>`. This will treat all descendant `<a href>` as `<Link>` components when they link to an internal URL ie. same origin.
+
+
+```tsx
+import { Links, LiveReload, Meta, Scripts, ScrollRestoration } from "remix";
+import { TreatAnchorsAsClientSideNavigation } from "remix-utils";
+
+export default function App() {
+  return (
+    <html lang="en">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <TreatAnchorsAsClientSideNavigation>
+          <Outlet />
+        </TreatAnchorsAsClientSideNavigation>
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+```
+
 ## Author
 
 - [Sergio Xalambrí](https://sergiodxa.com)

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,3 +1,4 @@
+export * from "./react/anchors-as-client-side-navigation";
 export * from "./react/cache-assets";
 export * from "./react/client-only";
 export * from "./react/csrf";

--- a/src/react/anchors-as-client-side-navigation.tsx
+++ b/src/react/anchors-as-client-side-navigation.tsx
@@ -1,0 +1,67 @@
+import { useNavigate } from "@remix-run/react";
+import { createContext, ReactNode, useContext, useEffect, useRef } from "react";
+
+export interface TreatAnchorsAsClientSideNavigationProps {
+  children: ReactNode;
+}
+
+const HasParentContext = createContext(false);
+
+export function TreatAnchorsAsClientSideNavigation({
+  children,
+}: TreatAnchorsAsClientSideNavigationProps) {
+  const navigate = useNavigate();
+  const ref = useRef<HTMLDivElement>(null);
+  const hasParent = useContext(HasParentContext);
+
+  useEffect(() => {
+    if (hasParent) {
+      console.error(
+        "TreatAnchorsAsClientSideNavigation can't be nested inside another TreatAnchorsAsClientSideNavigation. Ignoring this instance."
+      );
+      return;
+    }
+
+    const controller = new AbortController();
+    ref.current?.addEventListener(
+      "click",
+      (event) => {
+        const target = (event.target as Partial<HTMLElement>).closest?.("a");
+        if (!target) return;
+
+        const url = new URL(target.href, window.location.origin);
+        if (
+          url.origin === window.location.origin &&
+          // Ignore clicks with modifiers
+          !event.ctrlKey &&
+          !event.metaKey &&
+          !event.shiftKey &&
+          // Ignore right clicks
+          event.button === 0 &&
+          // Ignore if `target="_blank"`
+          [null, undefined, "", "self"].includes(target.target) &&
+          !target.hasAttribute("download")
+        ) {
+          event.preventDefault();
+          navigate(url.pathname + url.search + url.hash);
+        }
+      },
+      { signal: controller.signal }
+    );
+
+    return () => controller.abort();
+  }, [navigate, hasParent]);
+
+  // Don't bother wrapping the children in a div if we're already inside a
+  // TreatAnchorsAsClientSideNavigation
+  // This is a misconfiguration that we warn about in the above useEffect
+  return hasParent ? (
+    <>{children}</>
+  ) : (
+    <HasParentContext.Provider value={true}>
+      <div ref={ref} data-anchors-as-links>
+        {children}
+      </div>
+    </HasParentContext.Provider>
+  );
+}

--- a/test/react/anchors-as-client-side-navigation.test.tsx
+++ b/test/react/anchors-as-client-side-navigation.test.tsx
@@ -145,12 +145,18 @@ describe("nested configuration checks", () => {
   const nested = (
     <TreatAnchorsAsClientSideNavigation>
       <TreatAnchorsAsClientSideNavigation>
-        <a href="/link" target="_blank">
-          A link
-        </a>
+        <a href="/link">A link</a>
       </TreatAnchorsAsClientSideNavigation>
     </TreatAnchorsAsClientSideNavigation>
   );
+
+  test("it only calls navigate once", () => {
+    render(nested);
+    fireEvent.click(screen.getByText("A link"));
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith("/link");
+  });
 
   test("it warns when nested", () => {
     render(nested);
@@ -172,7 +178,6 @@ describe("nested configuration checks", () => {
         >
           <a
             href="/link"
-            target="_blank"
           >
             A link
           </a>

--- a/test/react/anchors-as-client-side-navigation.test.tsx
+++ b/test/react/anchors-as-client-side-navigation.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from "react";
+import { TreatAnchorsAsClientSideNavigation } from "../../src/react/anchors-as-client-side-navigation";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useNavigate } from "@remix-run/react";
+
+jest.mock("@remix-run/react");
+
+const navigate = jest.fn();
+
+beforeAll(() => {
+  (useNavigate as jest.MockedFunction<typeof useNavigate>).mockReturnValue(
+    navigate
+  );
+});
+
+afterEach(jest.clearAllMocks);
+
+test("it treats child anchors as links", () => {
+  render(
+    <TreatAnchorsAsClientSideNavigation>
+      <a href="/link">Some link</a>
+    </TreatAnchorsAsClientSideNavigation>
+  );
+
+  fireEvent.click(screen.getByText("Some link"));
+
+  expect(navigate).toHaveBeenCalledWith("/link");
+});
+
+test("handles query string and hash", () => {
+  render(
+    <TreatAnchorsAsClientSideNavigation>
+      <a href="/link#hash?query=string">Some link</a>
+    </TreatAnchorsAsClientSideNavigation>
+  );
+
+  fireEvent.click(screen.getByText("Some link"));
+
+  expect(navigate).toHaveBeenCalledWith("/link#hash?query=string");
+});
+
+test("handles children inside anchor", () => {
+  render(
+    <TreatAnchorsAsClientSideNavigation>
+      <a href="/link">
+        <span>
+          <span>Some link</span>
+        </span>
+      </a>
+    </TreatAnchorsAsClientSideNavigation>
+  );
+
+  fireEvent.click(screen.getByText("Some link"));
+
+  expect(navigate).toHaveBeenCalledWith("/link");
+});
+
+test("ignores non-anchors", () => {
+  render(
+    <TreatAnchorsAsClientSideNavigation>
+      <div>Not a link</div>
+    </TreatAnchorsAsClientSideNavigation>
+  );
+
+  fireEvent.click(screen.getByText("Not a link"));
+
+  expect(navigate).not.toHaveBeenCalled();
+});
+
+test("ignores external links", () => {
+  render(
+    <TreatAnchorsAsClientSideNavigation>
+      <a href="https://example.com">A link</a>
+    </TreatAnchorsAsClientSideNavigation>
+  );
+
+  fireEvent.click(screen.getByText("A link"));
+
+  expect(navigate).not.toHaveBeenCalled();
+});
+
+test("ignores internal download links", () => {
+  render(
+    <TreatAnchorsAsClientSideNavigation>
+      <a href="/download" download>
+        A link
+      </a>
+    </TreatAnchorsAsClientSideNavigation>
+  );
+
+  fireEvent.click(screen.getByText("A link"));
+
+  expect(navigate).not.toHaveBeenCalled();
+});
+
+test("ignore clicks with modifiers and right clicks", () => {
+  render(
+    <TreatAnchorsAsClientSideNavigation>
+      <a href="/link">A link</a>
+    </TreatAnchorsAsClientSideNavigation>
+  );
+
+  fireEvent.click(screen.getByText("A link"), {
+    ctrlKey: true,
+  });
+  fireEvent.click(screen.getByText("A link"), {
+    metaKey: true,
+  });
+  fireEvent.click(screen.getByText("A link"), {
+    shiftKey: true,
+  });
+  fireEvent.click(screen.getByText("A link"), {
+    button: 1,
+  });
+
+  expect(navigate).not.toHaveBeenCalled();
+});
+
+test("ignores links with target=_blank", () => {
+  render(
+    <TreatAnchorsAsClientSideNavigation>
+      <a href="/link" target="_blank">
+        A link
+      </a>
+    </TreatAnchorsAsClientSideNavigation>
+  );
+
+  fireEvent.click(screen.getByText("A link"));
+
+  expect(navigate).not.toHaveBeenCalled();
+});
+
+describe("nested configuration checks", () => {
+  const mockedConsoleError = jest.fn();
+  beforeAll(() => {
+    jest.spyOn(console, "error").mockImplementation(mockedConsoleError);
+  });
+  afterAll(() => {
+    jest.spyOn(console, "error").mockRestore();
+  });
+
+  const nested = (
+    <TreatAnchorsAsClientSideNavigation>
+      <TreatAnchorsAsClientSideNavigation>
+        <a href="/link" target="_blank">
+          A link
+        </a>
+      </TreatAnchorsAsClientSideNavigation>
+    </TreatAnchorsAsClientSideNavigation>
+  );
+
+  test("it warns when nested", () => {
+    render(nested);
+    expect(mockedConsoleError).toHaveBeenCalledWith(
+      "TreatAnchorsAsClientSideNavigation can't be nested inside another TreatAnchorsAsClientSideNavigation. Ignoring this instance."
+    );
+  });
+
+  test("it doesn't render the nested div", () => {
+    const { container } = render(nested);
+    expect(
+      container.querySelectorAll('div[data-anchors-as-links="true"]')
+    ).toHaveLength(1);
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          data-anchors-as-links="true"
+        >
+          <a
+            href="/link"
+            target="_blank"
+          >
+            A link
+          </a>
+        </div>
+      </div>
+    `);
+  });
+});


### PR DESCRIPTION
Adds a `<TreatAnchorsAsClientSideNavigation>` component that treats all `<a>` descendants with internal hrefs as if they were `<Link>` elements.

This allows you to opt into this behaviour scoped to just a portion of your app.