### PR TITLE
Add Typescript as a Peer Dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "@remix-run/react": "^1.10.0",
         "@remix-run/server-runtime": "^1.10.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "typescript": ">=4.1.0",
         "zod": "^3.19.1"
       }
     },
@@ -10267,9 +10268,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18302,9 +18303,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw=="
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@remix-run/react": "^1.10.0",
     "@remix-run/server-runtime": "^1.10.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "typescript": ">=4.1.0",
     "zod": "^3.19.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This silences a missing peer dependency warning in Yarn Stable.