### PR TITLE
Detect IP on Shopify Oxygen

### DIFF
--- a/src/server/get-client-ip-address.ts
+++ b/src/server/get-client-ip-address.ts
@@ -18,6 +18,7 @@ const headerNames = Object.freeze([
   "Forwarded-For",
   "Forwarded",
   "DO-Connecting-IP" /** Digital ocean app platform */,
+  "oxygen-buyer-ip" /** Shopify oxygen platform */
 ] as const);
 
 /**


### PR DESCRIPTION
👋🏼 Sergio, small PR to add support for Shopify Oxygen IP header. 

Should become very useful as Remix is more widely adopted inside Oxygen.

