### PR TITLE
Mention in SSE docs that support is limited by deployment platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1192,6 +1192,7 @@ There are two utils provided to help with the usage inside Remix:
 The `eventStream` function is used to create a new event stream response needed to send events to the client.
 
 ```ts
+// app/routes/sse.time.ts
 import { eventStream } from "remix-utils";
 
 export async function loader({ request }: LoaderArgs) {
@@ -1210,6 +1211,7 @@ export async function loader({ request }: LoaderArgs) {
 Then, inside any component, you can use the `useEventSource` hook to connect to the event stream.
 
 ```tsx
+// app/components/counter.ts
 import { useEventSource } from "remix-utils";
 
 function Counter() {
@@ -1229,7 +1231,8 @@ function Counter() {
 }
 ```
 
-The `event` name in both the event stream and the hook is optional, in which case it will default to `message`, if defined you must use the same event name in both sides, this also allows you to emit different events from the same event stream.
+The `event` name in both the event stream and the hook is optional, in which case it will default to `message`, if defined you must use the same event name in both sides, this also allows you to emit different events from the same event stream.\
+For Server-Sent Events to work, your server mus support HTTP streaming. Therefore, it won't work in services like AWS lambda.
 
 ### Rolling Cookies
 

--- a/README.md
+++ b/README.md
@@ -1232,7 +1232,8 @@ function Counter() {
 ```
 
 The `event` name in both the event stream and the hook is optional, in which case it will default to `message`, if defined you must use the same event name in both sides, this also allows you to emit different events from the same event stream.
-For Server-Sent Events to work, your server mus support HTTP streaming. Therefore, it won't work in services like AWS lambda.
+
+For Server-Sent Events to work, your server must support HTTP streaming. If you don't get SSE to work check if your deployment platform has support for it.
 
 ### Rolling Cookies
 

--- a/README.md
+++ b/README.md
@@ -1231,7 +1231,7 @@ function Counter() {
 }
 ```
 
-The `event` name in both the event stream and the hook is optional, in which case it will default to `message`, if defined you must use the same event name in both sides, this also allows you to emit different events from the same event stream.\
+The `event` name in both the event stream and the hook is optional, in which case it will default to `message`, if defined you must use the same event name in both sides, this also allows you to emit different events from the same event stream.
 For Server-Sent Events to work, your server mus support HTTP streaming. Therefore, it won't work in services like AWS lambda.
 
 ### Rolling Cookies


### PR DESCRIPTION
I added some extra information to the event source docs to avoid people why is the event source not working with the remix grunge stack