### PR TITLE
Fix document code block syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ export function useMarkAsRead() {
 
 Finally, you need to verify the authenticity token in the action that received the request.
 
-```t
+```ts
 import { verifyAuthenticityToken, redirectBack } from "remix-utils";
 import { getSession, commitSession } from "~/services/session.server";
 


### PR DESCRIPTION
One of the code block's syntax highlighting is off, missing a letter "s".