### PR TITLE
Fix types for RouteData

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@jest/types": "^27.2.5",
         "@remix-run/node": "^1.10.0",
         "@remix-run/react": "^1.10.0",
+        "@remix-run/router": "^1.0.0",
         "@remix-run/server-runtime": "^1.10.0",
         "@testing-library/jest-dom": "^5.15.0",
         "@testing-library/react": "^12.1.2",
@@ -60,6 +61,7 @@
       },
       "peerDependencies": {
         "@remix-run/react": "^1.10.0",
+        "@remix-run/router": "^1.0.0",
         "@remix-run/server-runtime": "^1.10.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "zod": "^3.19.1"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   ],
   "peerDependencies": {
     "@remix-run/react": "^1.10.0",
+    "@remix-run/router": "^1.0.0",
     "@remix-run/server-runtime": "^1.10.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "zod": "^3.19.1"
@@ -54,6 +55,7 @@
     "@jest/types": "^27.2.5",
     "@remix-run/node": "^1.10.0",
     "@remix-run/react": "^1.10.0",
+    "@remix-run/router": "^1.0.0",
     "@remix-run/server-runtime": "^1.10.0",
     "@testing-library/jest-dom": "^5.15.0",
     "@testing-library/react": "^12.1.2",

--- a/src/react/handle-conventions.ts
+++ b/src/react/handle-conventions.ts
@@ -1,7 +1,9 @@
-import { RouteData } from "@remix-run/react/dist/routeData";
+import type { RouterState } from "@remix-run/router";
 import type { AppData } from "@remix-run/server-runtime";
 import type { Location, Params } from "react-router-dom";
 import { Matches } from "./matches-type";
+
+type RouteData = RouterState["loaderData"];
 
 export type HandleConventionArguments<Data extends AppData = AppData> = {
   id: string;


### PR DESCRIPTION
Since remix-run/remix#5679 and remix v1.15.0, RouteData is no longer exported by Remix. The type is now provided by `@remix-run/router`.