### PR TITLE
Get RouteData type from @remix-run/router rather than internals

### DIFF
--- a/src/react/handle-conventions.ts
+++ b/src/react/handle-conventions.ts
@@ -4,9 +4,9 @@ import type { RouterState } from "@remix-run/router";
 type RouteData = RouterState["loaderData"];
 
 export type HandleConventionArguments<Data extends AppData = AppData> = {
-	id: string;
-	data: Data;
-	params: Params;
-	location: Location;
-	parentsData: RouteData;
+  id: string;
+  data: Data;
+  params: Params;
+  location: Location;
+  parentsData: RouteData;
 };

--- a/src/react/handle-conventions.ts
+++ b/src/react/handle-conventions.ts
@@ -1,11 +1,12 @@
-import { RouteData } from "@remix-run/react/dist/routeData";
 import type { AppData } from "@remix-run/server-runtime";
 import type { Location, Params } from "react-router-dom";
+import type { RouterState } from "@remix-run/router";
+type RouteData = RouterState["loaderData"];
 
 export type HandleConventionArguments<Data extends AppData = AppData> = {
-  id: string;
-  data: Data;
-  params: Params;
-  location: Location;
-  parentsData: RouteData;
+	id: string;
+	data: Data;
+	params: Params;
+	location: Location;
+	parentsData: RouteData;
 };


### PR DESCRIPTION
Fixes #190 