### PR TITLE
Consider revalidator state in global state hooks

### DIFF
--- a/src/react/use-global-pending-state.tsx
+++ b/src/react/use-global-pending-state.tsx
@@ -36,8 +36,8 @@ export function useGlobalTransitionStates() {
 }
 
 /**
- * Let you know if the app is pending some request, either global transition
- *, some fetcher transition or revalidation.
+ * Let you know if the app is pending some request, either global transition,
+ * some fetcher transition or revalidation.
  * @returns "idle" | "pending"
  */
 export function useGlobalPendingState() {
@@ -61,8 +61,8 @@ export function useGlobalSubmittingState() {
 }
 
 /**
- * Let you know if the app is loading some request, either global transition
- *, some fetcher transition or revalidation.
+ * Let you know if the app is loading some request, either global transition,
+ * some fetcher transition or revalidation.
  * @returns "idle" | "loading"
  */
 export function useGlobalLoadingState() {


### PR DESCRIPTION
Consider revalidator state for:
- useGlobalTransitionStates
- useGlobalPendingState
- useGlobalLoadingState

Closes #201 