### PR TITLE
replaced useTransition Hook with useNavigation

### DIFF
--- a/src/react/use-global-pending-state.tsx
+++ b/src/react/use-global-pending-state.tsx
@@ -1,4 +1,4 @@
-import { useTransition, useFetchers } from "@remix-run/react";
+import { useNavigation, useFetchers } from "@remix-run/react";
 import { useMemo } from "react";
 
 /**
@@ -15,7 +15,7 @@ import { useMemo } from "react";
  * // The app is idle
  */
 export function useGlobalTransitionStates() {
-  let transition = useTransition();
+  let transition = useNavigation();
   let fetchers = useFetchers();
 
   /**


### PR DESCRIPTION
Hi, 
I recently used useGlobalPendingState hook and ran into warning message for useTransition hook being used.
"useTransition will be removed in v2 in favor of [useNavigation](https://remix.run/docs/en/1.16.1/hooks/use-navigation)"
will it be possible to consider useNavigation instead of useTransition for useGlobalTransitionStates ?
I tried a sample in my local and seems to be fine for me.  Show casing the change I did as a PR (i didn't know how else to explain :)). I might have not thought it through. I was also thinking, should the function name remain the same ?

Please consider making the (useTransition => useNavigation) change when you can ? 