### PR TITLE
feat(honeypot): allow it to be disabled for testing

### DIFF
--- a/src/server/honeypot.ts
+++ b/src/server/honeypot.ts
@@ -2,14 +2,14 @@ import CryptoJS from "crypto-js";
 
 export interface HoneypotInputProps {
   nameFieldName: string;
-  validFromFieldName: string;
+  validFromFieldName: string | null;
   encryptedValidFrom: string;
 }
 
 export interface HonetpotConfig {
   randomizeNameFieldName?: boolean;
   nameFieldName?: string;
-  validFromFieldName?: string;
+  validFromFieldName?: string | null;
   encryptionSeed?: string;
 }
 
@@ -73,7 +73,10 @@ export class Honeypot {
   }
 
   protected get validFromFieldName() {
-    return this.config.validFromFieldName ?? DEFAULT_VALID_FROM_FIELD_NAME;
+    if (this.config.validFromFieldName === undefined) {
+      return DEFAULT_VALID_FROM_FIELD_NAME;
+    }
+    return this.config.validFromFieldName;
   }
 
   protected get encryptionSeed() {
@@ -94,7 +97,7 @@ export class Honeypot {
     formData: FormData,
     nameFieldName: string
   ): boolean {
-    return formData.has(nameFieldName) || formData.has(this.validFromFieldName);
+    return formData.has(nameFieldName) || Boolean(this.validFromFieldName && formData.has(this.validFromFieldName));
   }
 
   protected randomValue() {

--- a/src/server/honeypot.ts
+++ b/src/server/honeypot.ts
@@ -97,7 +97,10 @@ export class Honeypot {
     formData: FormData,
     nameFieldName: string
   ): boolean {
-    return formData.has(nameFieldName) || Boolean(this.validFromFieldName && formData.has(this.validFromFieldName));
+    return (
+      formData.has(nameFieldName) ||
+      Boolean(this.validFromFieldName && formData.has(this.validFromFieldName))
+    );
   }
 
   protected randomValue() {

--- a/test/server/honeypot.test.ts
+++ b/test/server/honeypot.test.ts
@@ -3,6 +3,10 @@ import CryptoJS from "crypto-js";
 
 import { Honeypot, SpamError } from "../../src";
 
+function invariant(condition: any, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
 describe(Honeypot.name, () => {
   test("generates input props", () => {
     let props = new Honeypot().getInputProps();
@@ -38,6 +42,7 @@ describe(Honeypot.name, () => {
     let honeypot = new Honeypot({ randomizeNameFieldName: true });
 
     let props = honeypot.getInputProps();
+    invariant(props.validFromFieldName, "validFromFieldName is null");
 
     let formData = new FormData();
     formData.set(props.nameFieldName, "");
@@ -48,11 +53,13 @@ describe(Honeypot.name, () => {
 
   test("fails validity check if input is not present", () => {
     let honeypot = new Honeypot();
+    let props = honeypot.getInputProps()
+    invariant(props.validFromFieldName, "validFromFieldName is null");
 
     let formData = new FormData();
     formData.set(
-      honeypot.getInputProps().validFromFieldName,
-      honeypot.getInputProps().encryptedValidFrom
+      props.validFromFieldName,
+      props.encryptedValidFrom
     );
 
     expect(() => honeypot.check(formData)).toThrowError(
@@ -89,6 +96,7 @@ describe(Honeypot.name, () => {
       encryptionSeed: "SEED",
     });
     let props = honeypot.getInputProps();
+    invariant(props.validFromFieldName, "validFromFieldName is null");
 
     let formData = new FormData();
     formData.set(props.nameFieldName, "");
@@ -108,6 +116,7 @@ describe(Honeypot.name, () => {
     });
 
     let props = honeypot.getInputProps();
+    invariant(props.validFromFieldName, "validFromFieldName is null");
 
     let formData = new FormData();
     formData.set(props.nameFieldName, "");
@@ -120,4 +129,18 @@ describe(Honeypot.name, () => {
       new SpamError("Honeypot valid from is in future")
     );
   });
+
+  test("does not check for valid from timestamp if it's set to null", () => {
+    let honeypot = new Honeypot({
+      validFromFieldName: null,
+    });
+
+    let props = honeypot.getInputProps();
+    expect(props.validFromFieldName).toBeNull();
+
+    let formData = new FormData();
+    formData.set(props.nameFieldName, "");
+
+    expect(() => honeypot.check(formData)).not.toThrow();
+  })
 });

--- a/test/server/honeypot.test.ts
+++ b/test/server/honeypot.test.ts
@@ -53,14 +53,11 @@ describe(Honeypot.name, () => {
 
   test("fails validity check if input is not present", () => {
     let honeypot = new Honeypot();
-    let props = honeypot.getInputProps()
+    let props = honeypot.getInputProps();
     invariant(props.validFromFieldName, "validFromFieldName is null");
 
     let formData = new FormData();
-    formData.set(
-      props.validFromFieldName,
-      props.encryptedValidFrom
-    );
+    formData.set(props.validFromFieldName, props.encryptedValidFrom);
 
     expect(() => honeypot.check(formData)).toThrowError(
       new SpamError("Missing honeypot input")
@@ -142,5 +139,5 @@ describe(Honeypot.name, () => {
     formData.set(props.nameFieldName, "");
 
     expect(() => honeypot.check(formData)).not.toThrow();
-  })
+  });
 });


### PR DESCRIPTION
This allows users to disable the time feature of the honeypot for E2E testing purposes:

```ts
export const honeypot = new Honeypot({
	validFromFieldName: process.env.TESTING ? undefined : null,
	encryptionSeed: process.env.HONEYPOT_SECRET,
})
```