### PR TITLE
feat: support not regenerating the csrf token

### DIFF
--- a/src/server/csrf.ts
+++ b/src/server/csrf.ts
@@ -61,6 +61,8 @@ export class CSRF {
 
   /**
    * Generates a token and serialize it into the cookie.
+   * @param requestOrHeaders A request or headers object from which we can
+   * get the cookie to get the existing token.
    * @param bytes The number of bytes used to generate the token
    * @returns A tuple with the token and the string to send in Set-Cookie
    * If there's already a csrf value in the cookie then the token will

--- a/test/server/csrf.test.ts
+++ b/test/server/csrf.test.ts
@@ -147,4 +147,14 @@ describe("CSRF", () => {
     expect(cookieHeader).toStrictEqual(expect.any(String));
     expect(token).toEqual(parsedCookie);
   });
+
+  test("does not return a cookie header if there's already a value", async () => {
+    let originalToken = csrf.generate();
+    let headers = new Headers({
+      cookie: await cookie.serialize(originalToken),
+    });
+    let [token, cookieHeader] = await csrf.commitToken(headers);
+    expect(token).toBe(originalToken);
+    expect(cookieHeader).toBe(null);
+  });
 });


### PR DESCRIPTION
This fixes this problem:

Do this:
1. Open app in tab 1
2. Open app in tab 2
3. Submit form in tab 1 <-- CSRF error