### PR TITLE
Support withCredentials in useEventSource()

### DIFF
--- a/src/react/use-event-source.tsx
+++ b/src/react/use-event-source.tsx
@@ -9,17 +9,19 @@ type EventSourceOptions = {
  * Subscribe to an event source and return the latest event.
  * @param url The URL of the event source to connect to
  * @param options The options to pass to the EventSource constructor
+ * @property withCredentials If true, send CORS headers
  * @returns The last event received from the server
  */
 export function useEventSource(
   url: string | URL,
-  { event = "message", init }: EventSourceOptions = {}
+  { event = "message", init = {} }: EventSourceOptions = {}
 ) {
   const [data, setData] = useState<string | null>(null);
+  const withCredentials = init.withCredentials;
 
   useEffect(() => {
-    const eventSource = new EventSource(url, init);
-    eventSource.addEventListener(event ?? "message", handler);
+    const eventSource = new EventSource(url, { withCredentials });
+    eventSource.addEventListener("message", handler);
 
     // rest data if dependencies change
     setData(null);
@@ -32,7 +34,7 @@ export function useEventSource(
       eventSource.removeEventListener(event ?? "message", handler);
       eventSource.close();
     };
-  }, [url, event, init]);
+  }, [url, event, withCredentials]);
 
   return data;
 }


### PR DESCRIPTION
If you pass an object as init the hook will call open and immediately close every render because the init object is a by-reference dependency of the useEffect. [MDN](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/EventSource#options) currently only documents one possible option: withCredentials: boolean;.

In this PR I just handle withCredentials specially. An alternative would be to just remove init from the dependency array because changing it after creating the EventSource doesn't make sense. Another possible solution is to use JSON.stringify() outside the useEffect and JSON.parse() inside the useEffect.