### PR TITLE
Convert remix-utils to regex on serverDependenciesToBundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In your `remix.config.js` file, add this:
 ```js
 module.exports = {
 	serverDependenciesToBundle: [
-		"remix-utils",
+		/^remix-utils.*/,
 		// If you installed is-ip optional dependency you will need these too
 		"is-ip",
 		"ip-regex",
@@ -58,10 +58,6 @@ module.exports = {
 	],
 };
 ```
-
-> **Warning**
-> Until https://github.com/remix-run/remix/pull/7272 is released you will need to add every individual util to `serverDependenciesToBundle` instead of just `remix-utils`.
-
 If you're not sure if your app uses ESM or CJS, check if you have `serverModuleFormat` in your `remix.config.js` file to know.
 
 In case you don't have one, if you're using Remix v1 it will be CJS and if you're using Remix v2 it will be ESM.


### PR DESCRIPTION
While attempting to upgrade Remix Utils to the latest version, I encountered the following error:
```
Error [ERR_REQUIRE_ESM]: require() of ES Module ... Instead change the require of promise.js 
``` 
Diving deeper I realized that the error was due to my oversight. I had overlooked the warning to _add each individual utility_ to the serverDependenciesToBundle configuration. Subsequently, I also noticed that a related pull request ([PR](https://github.com/remix-run/remix/pull/7272)) had been merged into Remix version [2.0.1](https://github.com/remix-run/remix/releases/tag/remix%402.0.1) but had not completely resolved the issue.

By adding `/^remix-utils.*/,` in lieu of `"remix-utils"` and every individual util to `serverDependenciesToBundle`, it stops showing the error.