### PR TITLE
Add "id" attribute to Honeypot input

### DIFF
--- a/src/react/honeypot.tsx
+++ b/src/react/honeypot.tsx
@@ -38,6 +38,7 @@ export function HoneypotInputs({
 				<>
 					<label htmlFor={validFromFieldName}>{label}</label>
 					<input
+						id={validFromFieldName}
 						name={validFromFieldName}
 						type="text"
 						value={encryptedValidFrom}


### PR DESCRIPTION
The label was pointing to the input using the ID, but the input didn't set the ID, breaking the relation between the label and the input.