### PR TITLE
Fix broken honeypot-inputs import in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1914,7 +1914,7 @@ export default function Component() {
 Now, in every public form you want protect against spam (like a login form), render the `HoneypotInputs` component.
 
 ```tsx
-import { HoneypotInputs } from "remix-utils/honeypot-inputs";
+import { HoneypotInputs } from "remix-utils/honeypot/react";
 
 function SomePublicForm() {
 	return (


### PR DESCRIPTION
Small change in the docs, assuming this was just a change of API before release