### PR TITLE
Deduplicate connections to SSE with useEventSource regardless of the event

### DIFF
--- a/src/react/use-event-source.ts
+++ b/src/react/use-event-source.ts
@@ -30,7 +30,7 @@ export function useEventSource(
 	let [data, setData] = useState<string | null>(null);
 
 	useEffect(() => {
-		let key = [url.toString(), event, init?.withCredentials].join("::");
+		let key = [url.toString(), init?.withCredentials].join("::");
 
 		let value = map.get(key) ?? {
 			count: 0,


### PR DESCRIPTION
`use-event-source` has a feature to deduplicate SSE connections in order to lower the number of `EventStream`s a browser needs to hold. However, when event name is the only differences, it creates multiple identical `EventStream`s and then on client side it listens to different events.

Instead, we can create a single `EventStream` for the same URL and withCredentials flag, no matter what event is.

### Example

Given code like these
```ts
  const pinged = !!useEventSource(`/events`, { event: "ping" });
```
```ts
  const users = useEventSource(`/events`, { event: "users" });
```

It creates identical event streams

![duplicate-sse-connections](https://github.com/sergiodxa/remix-utils/assets/736244/f304e0ec-8ad6-4fe9-89e1-f47b9fae0658)

after

![Screenshot 2023-11-25 at 9 44 04](https://github.com/sergiodxa/remix-utils/assets/736244/d05347cf-4aa3-46de-b876-a34f97fdbf32)
