### PR TITLE
Allow passing input props to ExistingSearchParams

### DIFF
--- a/src/react/existing-search-params.tsx
+++ b/src/react/existing-search-params.tsx
@@ -48,10 +48,10 @@ export function ExistingSearchParams({ exclude, ...props }: Props) {
 				return (
 					<input
 						key={`${key}=${value}`}
+						{...props}
 						type="hidden"
 						name={key}
 						value={value}
-						{...props}
 					/>
 				);
 			})}

--- a/src/react/existing-search-params.tsx
+++ b/src/react/existing-search-params.tsx
@@ -8,7 +8,10 @@ type Props = {
 	 *  - any params from other forms you want to clear on submit
 	 */
 	exclude?: Array<string | undefined>;
-};
+} & Omit<
+	React.InputHTMLAttributes<HTMLInputElement>,
+	"name" | "value" | "type" | "id"
+>;
 
 /**
  * Include existing query params as hidden inputs in a form.
@@ -33,7 +36,7 @@ type Props = {
  * </Form>
  * ```
  */
-export function ExistingSearchParams({ exclude }: Props) {
+export function ExistingSearchParams({ exclude, ...props }: Props) {
 	const [searchParams] = useSearchParams();
 	const existingSearchParams = [...searchParams.entries()].filter(
 		([key]) => !exclude?.includes(key),
@@ -48,6 +51,7 @@ export function ExistingSearchParams({ exclude }: Props) {
 						type="hidden"
 						name={key}
 						value={value}
+						{...props}
 					/>
 				);
 			})}


### PR DESCRIPTION
This PR extends the ExistingSearchParams component to accept all input props and will pass them to the created inputs. 

Exceptions are made for name, value, and type (which are controlled by ExistingSearchParams) as well as id, which would cause non-unique ID related bugs. 