### PR TITLE
Fix useDebounceSubmit recursively calling itself

### DIFF
--- a/src/react/use-debounce-fetcher.ts
+++ b/src/react/use-debounce-fetcher.ts
@@ -47,18 +47,21 @@ export function useDebounceFetcher<Data>() {
 
 	let fetcher = useFetcher<Data>() as DebouncedFetcher<Data>;
 
+	// Clone the original submit to avoid a recursive loop
+	const originalSubmit = fetcher.submit;
+
 	fetcher.submit = useCallback(
 		(target, { debounceTimeout = 0, ...options } = {}) => {
 			if (timeoutRef.current) clearTimeout(timeoutRef.current);
 			if (!debounceTimeout || debounceTimeout <= 0) {
-				return fetcher.submit(target, options);
+				return originalSubmit(target, options);
 			}
 
 			timeoutRef.current = setTimeout(() => {
-				fetcher.submit(target, options);
+				originalSubmit(target, options);
 			}, debounceTimeout);
 		},
-		[fetcher],
+		[originalSubmit],
 	);
 
 	return fetcher;


### PR DESCRIPTION
In my original useDebounceSubmit implementation, I used a separate debounceSubmit method to prevent a recursive loop where when the debounced fetcher finally submits, it triggers a new debounce call and overflows the call stack

The version currently in remix-utils suffers this bug, but it can be avoided without renaming the submit call by storing the initial submit function and avoiding re-calling the debounced version afterward

Once merged I will update my blog posts and examples to use this util instead of my original implementation