### PR TITLE
Update CI to run for external contributors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
`push` only works for pushes to branches in the repository which means pull requests from forks won't trigger it.

This change limits the workflow running on push to the `main` branch, meaning everyone including maintainers with write access to this repository will now need to open a PR to have CI run but this is generally fine if you're already following a PR based flow (which most people do), and avoids running the workflow twice for PRs (once for the `push` trigger and then again for the `pull_request` trigger) which is a little nicer on 🌎 