### PR TITLE
Fix ReturnType useDebounceFetcher

### DIFF
--- a/src/react/use-debounce-fetcher.ts
+++ b/src/react/use-debounce-fetcher.ts
@@ -1,3 +1,4 @@
+import type { SerializeFrom } from "@remix-run/server-runtime";
 import type {
 	SubmitOptions,
 	FetcherWithComponents,
@@ -30,7 +31,7 @@ type DebounceSubmitFunction = (
 ) => void;
 
 type DebouncedFetcher<Data = unknown> = Omit<
-	FetcherWithComponents<Data>,
+	FetcherWithComponents<SerializeFrom<Data>>,
 	"submit"
 > & { submit: DebounceSubmitFunction };
 


### PR DESCRIPTION
`fetcher.data` should infer the response data from your `action` or `loader`. However, in the current implementation, `fetcher.data` infer the type of your `action`  or `loader`  itself.

Modify type to allow useDebounceFetcher to infer the return value correctly.
I am referencing the following source code in Remix.
https://github.com/remix-run/remix/blob/bc0b77569655a163f3c5ebc87ad034a5fc297e2b/packages/remix-react/components.tsx#L1038-L1042

**Example**
before
![before fix](https://github.com/sergiodxa/remix-utils/assets/85535158/47422668-4ae2-4195-af5d-573462f0eb43)
after
![after fix](https://github.com/sergiodxa/remix-utils/assets/85535158/d878ebd6-ff44-494f-b15b-c4d414211d07)

If the use of `@remix-run/server-runtime` is undesirable, I'm considering modifying the code as follows. What do you think?:
```tsx
type DebouncedFetcher<Data = unknown> = Omit<
	ReturnType<typeof useFetcher<Data>>,
	"submit"
> & { submit: DebounceSubmitFunction };
```