### PR TITLE
Add new eventStream API for async generators

### DIFF
--- a/test/server/event-stream.test.ts
+++ b/test/server/event-stream.test.ts
@@ -3,103 +3,277 @@ import { vi, describe, test, expect } from "vitest";
 import { eventStream } from "../../src/server/event-stream";
 
 describe(eventStream, () => {
-	test("returns a response", () => {
-		let controller = new AbortController();
-		let response = eventStream(controller.signal, (_, __) => {
-			return () => {};
+	describe("Emitter API", () => {
+		test("returns a response", () => {
+			let controller = new AbortController();
+			let response = eventStream(controller.signal, () => {
+				return () => {};
+			});
+			controller.abort();
+			expect(response).toBeInstanceOf(Response);
 		});
-		controller.abort();
-		expect(response).toBeInstanceOf(Response);
+
+		test("response is a readable stream", async () => {
+			let controller = new AbortController();
+			let response = eventStream(controller.signal, () => {
+				return () => {};
+			});
+			controller.abort();
+			if (!response.body) throw new Error("Response body is undefined");
+			let reader = response.body.getReader();
+			let { done } = await reader.read();
+			expect(done).toBe(true);
+		});
+
+		test("can send data to the client with the send function", async () => {
+			let controller = new AbortController();
+			let response = eventStream(controller.signal, (send) => {
+				send({ data: "hello" });
+				return () => {};
+			});
+
+			controller.abort();
+
+			if (!response.body) throw new Error("Response body is undefined");
+
+			let reader = response.body.getReader();
+
+			let { value: event } = await reader.read();
+			expect(event).toEqual(new TextEncoder().encode("event: message\n"));
+
+			let { value: data } = await reader.read();
+			expect(data).toEqual(new TextEncoder().encode("data: hello\n\n"));
+
+			let { done } = await reader.read();
+			expect(done).toBe(true);
+		});
+
+		test("cleanup function is called when the client closes the connection", () => {
+			let fn = vi.fn();
+
+			let controller = new AbortController();
+
+			eventStream(controller.signal, () => fn);
+
+			controller.abort();
+
+			expect(fn).toHaveBeenCalledOnce();
+		});
+
+		describe("Headers Overrides", () => {
+			test("overrrides Content-Type header", () => {
+				let spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+				let response = eventStream(
+					new AbortController().signal,
+					(_, abort) => {
+						return () => abort();
+					},
+					{ headers: { "Content-Type": "text/html" } },
+				);
+
+				expect(spy).toHaveBeenCalledWith(
+					"Overriding Content-Type header to `text/event-stream`",
+				);
+
+				expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+			});
+
+			test("overrides Cache-Control", () => {
+				let spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+				let response = eventStream(
+					new AbortController().signal,
+					(_, abort) => {
+						return () => abort();
+					},
+					{ headers: { "Cache-Control": "max-age=60" } },
+				);
+
+				expect(spy).toHaveBeenCalledWith(
+					"Overriding Cache-Control header to `no-cache`",
+				);
+
+				expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+			});
+
+			test("overrides Connection", () => {
+				let spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+				let response = eventStream(
+					new AbortController().signal,
+					(_, abort) => {
+						return () => abort();
+					},
+					{ headers: { Connection: "close" } },
+				);
+
+				expect(spy).toHaveBeenCalledWith(
+					"Overriding Connection header to `keep-alive`",
+				);
+
+				expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+			});
+		});
 	});
 
-	test("response is a readable stream", async () => {
-		let controller = new AbortController();
-		let response = eventStream(controller.signal, (_, __) => {
-			return () => {};
-		});
-		controller.abort();
-		if (!response.body) throw new Error("Response body is undefined");
-		let reader = response.body.getReader();
-		let { done } = await reader.read();
-		expect(done).toBe(true);
-	});
-
-	test("can send data to the client with the send function", async () => {
-		let controller = new AbortController();
-		let response = eventStream(controller.signal, (send, _) => {
-			send({ data: "hello" });
-			return () => {};
+	describe("Stream API", () => {
+		test("returns a response", () => {
+			let controller = new AbortController();
+			let response = eventStream(controller.signal, {
+				cleanup() {},
+				handle() {},
+			});
+			controller.abort();
+			expect(response).toBeInstanceOf(Response);
 		});
 
-		controller.abort();
+		test("response is a readable stream", async () => {
+			let controller = new AbortController();
+			let response = eventStream(controller.signal, {
+				cleanup() {},
+				handle() {},
+			});
+			controller.abort();
+			if (!response.body) throw new Error("Response body is undefined");
+			let reader = response.body.getReader();
+			let { done } = await reader.read();
+			expect(done).toBe(true);
+		});
 
-		if (!response.body) throw new Error("Response body is undefined");
-
-		let reader = response.body.getReader();
-
-		let { value: event } = await reader.read();
-		expect(event).toEqual(new TextEncoder().encode("event: message\n"));
-
-		let { value: data } = await reader.read();
-		expect(data).toEqual(new TextEncoder().encode("data: hello\n\n"));
-
-		let { done } = await reader.read();
-		expect(done).toBe(true);
-	});
-
-	describe("Headers Overrides", () => {
-		test("overrrides Content-Type header", () => {
-			let spy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-			let response = eventStream(
-				new AbortController().signal,
-				(_, abort) => {
-					return () => abort();
+		test("can send data to the client with the send function", async () => {
+			let controller = new AbortController();
+			let response = eventStream(controller.signal, {
+				cleanup() {},
+				handle(send) {
+					send({ data: "hello" });
 				},
-				{ headers: { "Content-Type": "text/html" } },
-			);
+			});
 
-			expect(spy).toHaveBeenCalledWith(
-				"Overriding Content-Type header to `text/event-stream`",
-			);
+			controller.abort();
 
-			expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+			if (!response.body) throw new Error("Response body is undefined");
+
+			let reader = response.body.getReader();
+
+			let { value: event } = await reader.read();
+			expect(event).toEqual(new TextEncoder().encode("event: message\n"));
+
+			let { value: data } = await reader.read();
+			expect(data).toEqual(new TextEncoder().encode("data: hello\n\n"));
+
+			let { done } = await reader.read();
+			expect(done).toBe(true);
 		});
 
-		test("overrides Cache-Control", () => {
-			let spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		test("cleanup function is called when the client closes the connection", () => {
+			let fn = vi.fn();
 
-			let response = eventStream(
-				new AbortController().signal,
-				(_, abort) => {
-					return () => abort();
-				},
-				{ headers: { "Cache-Control": "max-age=60" } },
-			);
+			let controller = new AbortController();
 
-			expect(spy).toHaveBeenCalledWith(
-				"Overriding Cache-Control header to `no-cache`",
-			);
+			eventStream(controller.signal, { cleanup: fn, handle() {} });
 
-			expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+			controller.abort();
+
+			expect(fn).toHaveBeenCalledOnce();
 		});
 
-		test("overrides Connection", () => {
-			let spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		test("subscribes to stream of data and cleanup", async () => {
+			let controller = new AbortController();
 
-			let response = eventStream(
-				new AbortController().signal,
-				(_, abort) => {
-					return () => abort();
+			let fn = vi.fn();
+
+			let stream = createStream();
+			let response = eventStream(controller.signal, {
+				async cleanup() {
+					fn(await stream.return(10));
 				},
-				{ headers: { Connection: "close" } },
-			);
+				async handle(send, abort) {
+					for await (let chunk of stream) send({ data: chunk.toString() });
+					abort();
+				},
+			});
 
-			expect(spy).toHaveBeenCalledWith(
-				"Overriding Connection header to `keep-alive`",
-			);
+			if (!response.body) throw new Error("Response body is undefined");
 
-			expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+			let buffer = await response.arrayBuffer();
+
+			expect(new TextDecoder().decode(buffer)).toMatchInlineSnapshot(`
+				"event: message
+				data: 1
+
+				event: message
+				data: 2
+
+				event: message
+				data: 3
+
+				event: message
+				data: 4
+
+				event: message
+				data: 5
+
+				"
+			`);
+
+			expect(fn).toHaveBeenCalledWith({ done: true, value: 10 });
+		});
+
+		describe("Headers Overrides", () => {
+			test("overrrides Content-Type header", () => {
+				let spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+				let response = eventStream(
+					new AbortController().signal,
+					{ cleanup() {}, handle() {} },
+					{ headers: { "Content-Type": "text/html" } },
+				);
+
+				expect(spy).toHaveBeenCalledWith(
+					"Overriding Content-Type header to `text/event-stream`",
+				);
+
+				expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+			});
+
+			test("overrides Cache-Control", () => {
+				let spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+				let response = eventStream(
+					new AbortController().signal,
+					{ cleanup() {}, handle() {} },
+					{ headers: { "Cache-Control": "max-age=60" } },
+				);
+
+				expect(spy).toHaveBeenCalledWith(
+					"Overriding Cache-Control header to `no-cache`",
+				);
+
+				expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+			});
+
+			test("overrides Connection", () => {
+				let spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+				let response = eventStream(
+					new AbortController().signal,
+					{ cleanup() {}, handle() {} },
+					{ headers: { Connection: "close" } },
+				);
+
+				expect(spy).toHaveBeenCalledWith(
+					"Overriding Connection header to `keep-alive`",
+				);
+
+				expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+			});
 		});
 	});
 });
+
+async function* createStream() {
+	let count = 0;
+	while (count < 5) yield ++count;
+	return count;
+}


### PR DESCRIPTION
The eventStream response helpers is based a lot on how useEffect works, you pass a function and that function returns another one that's used to cleanup any side-effect.

This is great for event emitters like API where you have a function used to subscribe to events and another to unsubscribe, e.g.

```ts
return eventStream(request.signal, send => {
  emitter.addEventListener("event", handler)
  return () => emitter.removeEventListener("event", handler);

  function handler(event: Event) {
    send({ data: event });
  }
}
```

Or another common API is for cases where you get the unsubscribe function, e.g.

```ts
return eventStream(request.signal, (send) =>
  emitter.subscribe((event) => {
    send({ data: event });
  }),
);
```

Both are great, but if you want to iterate an AsyncIterator, you will need to create a function just to have the async code inside it.

```ts
return eventStream(request.signal, (send) => {
  run()
  return () => {}; // empty cleanup

  async function run() {
    for await (const chunk of stream) {
      if (request.signal.aborted) return;
      send({ data: chunk });
    }
  }
});
```

This PR introduce an alternative API that will help with this my splitting the `handle` and `cleanup` functions.

```ts
let stream = new Stream(); // get your stream here

return eventStream(request.signal, {
  // This function will be called when the connection is closed, it can be an
  // async function or a sync function, depends on your needs.
  cleanup() {
    return stream.close()
  },

  // This function will be called when the connection is open, here you can send
  // data to the browser or close the connection
  async handle(send, close) {
    // iterate the async stream of data
    for await (const chunk of stream) {
      // stop the iteration if the connection is closed
      if (request.signal.aborted) return;
      send({ data: chunk }); // send each chunk
    }

    return close(); // close the connection when the stream ends
  }
});
```

A more real-world example usage for this is using the OpenAI SDK.

```ts
import { client } from "~/services/openai.server";

export async function loader({ request }: LoaderFunctionArgs) {
  let stream = await client.chat.completions.create({
    model: "gpt-4",
    messages: [{ role: "user", content: "Say this is a test" }],
    stream: true,
  });

  return eventStream(controller.signal, {
    cleanup() {
      stream.controller.abort();
    },
    async handle(send, close) {
      for await (const chunk of stream) {
        send({ data: chunk.choices[0]?.delta?.content || "" });
      }

      return close();
    },
  });
}
```