### PR TITLE
Add enabled flag to useEventSource (default = true)

### DIFF
--- a/src/react/use-event-source.ts
+++ b/src/react/use-event-source.ts
@@ -3,6 +3,7 @@ import { createContext, useContext, useEffect, useState } from "react";
 export interface EventSourceOptions {
 	init?: EventSourceInit;
 	event?: string;
+	enabled?: boolean;
 }
 
 export type EventSourceMap = Map<
@@ -24,12 +25,16 @@ export const EventSourceProvider = context.Provider;
  */
 export function useEventSource(
 	url: string | URL,
-	{ event = "message", init }: EventSourceOptions = {},
+	{ event = "message", init, enabled = true }: EventSourceOptions = {},
 ) {
 	let map = useContext(context);
 	let [data, setData] = useState<string | null>(null);
 
 	useEffect(() => {
+		if (!enabled) {
+			return undefined;
+		}
+
 		let key = [url.toString(), init?.withCredentials].join("::");
 
 		let value = map.get(key) ?? {
@@ -58,7 +63,7 @@ export function useEventSource(
 				map.delete(key);
 			}
 		};
-	}, [url, event, init, map]);
+	}, [url, event, init, map, enabled]);
 
 	return data;
 }


### PR DESCRIPTION
This is a pattern that I find really useful in React Query, which allows you to defer the creation of the underlying connection/request until some other condition is met, without having to extract the hook out into another component, which can be awkward and reduce visibility.

I've defaulted the option to `true` to maintain backwards compatibility with existing behavior.

Inspired by a [converstion](https://x.com/jacobmparis/status/1835298647757774977) on Twitter (yes, _Twitter_).

> [!NOTE]
> I didn't see any existing test coverage in the repo for `useEventSource`, so I didn't add any tests for this.

## Example:

```ts
export function Component() {
  // Fetcher to initiate some long-lived process
  const fetcher = useFetcher();

  const progress = useEventSource(`/api/progress?id=${fetcher.data?.id}`, {
    enabled: !!fetcher.data?.id
  });

  return (
    <>
      {progress ? (
        <button onClick={() => fetcher.submit('/api/start', { method: 'POST' })}>
          Start Process
        </button>
      ) : (
        <Progress data={progress} />
      )}
    </>   
  );
}
```