### PR TITLE
Switch to type only import for `type-fest`

### DIFF
--- a/src/server/cors.ts
+++ b/src/server/cors.ts
@@ -1,4 +1,4 @@
-import { type Promisable } from "type-fest";
+import type { Promisable } from "type-fest";
 
 type Origin = boolean | string | RegExp | Array<string | RegExp>;
 


### PR DESCRIPTION
Running into an issue when bundling for vercel.

`import {} from "type-fest";` remains in the compiled code, and vite tries to bundle it in the SSR bundle.

However the module doesn't have an actual entry point, and this leads to a build error.