### PR TITLE
Allow custom queuing strategy for event streams

### DIFF
--- a/src/server/event-stream.test.ts
+++ b/src/server/event-stream.test.ts
@@ -54,6 +54,19 @@ describe(eventStream.name, () => {
 		expect(done).toBe(true);
 	});
 
+	test("accepts custom queuing strategy", () => {
+		expect(() =>
+			eventStream(
+				new AbortController().signal,
+				(_, abort) => {
+					return () => abort();
+				},
+				undefined,
+				new CountQueuingStrategy({ highWaterMark: 2 }),
+			),
+		).not.toThrow();
+	});
+
 	describe("Headers Overrides", () => {
 		test("overrrides Content-Type header", () => {
 			// biome-ignore lint/suspicious/noEmptyBlockStatements: Test

--- a/src/server/event-stream.ts
+++ b/src/server/event-stream.ts
@@ -27,41 +27,45 @@ export function eventStream(
 	signal: AbortSignal,
 	init: InitFunction,
 	options: ResponseInit = {},
+	strategy?: QueuingStrategy,
 ) {
-	let stream = new ReadableStream({
-		start(controller) {
-			let encoder = new TextEncoder();
-			let closed = false;
+	let stream = new ReadableStream(
+		{
+			start(controller) {
+				let encoder = new TextEncoder();
+				let closed = false;
 
-			function send({ event = "message", data }: SendFunctionArgs) {
-				if (closed) return; // If already closed, not enqueue anything
-				controller.enqueue(encoder.encode(`event: ${event}\n`));
-
-				if (closed) return; // If already closed, not enqueue anything
-
-				data.split("\n").forEach((line, index, array) => {
+				function send({ event = "message", data }: SendFunctionArgs) {
 					if (closed) return; // If already closed, not enqueue anything
-					let value = `data: ${line}\n`;
-					if (index === array.length - 1) value += "\n";
-					controller.enqueue(encoder.encode(value));
-				});
-			}
+					controller.enqueue(encoder.encode(`event: ${event}\n`));
 
-			let cleanup = init(send, close);
+					if (closed) return; // If already closed, not enqueue anything
 
-			function close() {
-				if (closed) return;
-				cleanup();
-				closed = true;
-				signal.removeEventListener("abort", close);
-				controller.close();
-			}
+					data.split("\n").forEach((line, index, array) => {
+						if (closed) return; // If already closed, not enqueue anything
+						let value = `data: ${line}\n`;
+						if (index === array.length - 1) value += "\n";
+						controller.enqueue(encoder.encode(value));
+					});
+				}
 
-			signal.addEventListener("abort", close);
+				let cleanup = init(send, close);
 
-			if (signal.aborted) return close();
+				function close() {
+					if (closed) return;
+					cleanup();
+					closed = true;
+					signal.removeEventListener("abort", close);
+					controller.close();
+				}
+
+				signal.addEventListener("abort", close);
+
+				if (signal.aborted) return close();
+			},
 		},
-	});
+		strategy,
+	);
 
 	let headers = new Headers(options.headers);
 


### PR DESCRIPTION
Functionality
---
Adds ability to use a user-defined queuing strategy for `eventStream()`.

Reason for this PR
---
The [default queuing strategy](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/ReadableStream#queuingstrategy) can apparently cause memory issues server-side due to backpressure, even for the most simplest of cases.

Issues tested with code from this [blog post](https://sergiodxa.com/tutorials/use-server-sent-events-with-remix).

The internal queue of the `ReadableStream` is never getting fully cleared out, and is steadily consuming more memory with each `send()` call.

After adjusting the queuing strategy to `new CountQueuingStartegy({ highWaterMark: 2 })`, the memory issues stopped.