### PR TITLE
fix type only import

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
 		"node": ">=20.0.0"
 	},
 	"type": "module",
-	"funding": [
-		"https://github.com/sponsors/sergiodxa"
-	],
+	"funding": ["https://github.com/sponsors/sergiodxa"],
 	"exports": {
 		"./package.json": "./package.json",
 		"./promise": "./build/common/promise.js",
@@ -150,9 +148,5 @@
 	"dependencies": {
 		"type-fest": "^4.30.0"
 	},
-	"files": [
-		"build",
-		"package.json",
-		"README.md"
-	]
+	"files": ["build", "package.json", "README.md"]
 }

--- a/src/server/redirect-back.ts
+++ b/src/server/redirect-back.ts
@@ -1,4 +1,4 @@
-import { UNSAFE_DataWithResponseInit, data } from "react-router";
+import { type UNSAFE_DataWithResponseInit, data } from "react-router";
 
 /**
  * Create a new Response with a redirect set to the URL the user was before.


### PR DESCRIPTION
Errors:
```
import { UNSAFE_DataWithResponseInit, data } from "react-router";
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: Named export 'UNSAFE_DataWithResponseInit' not found.
```