### PR TITLE
Add `nonce` prop to ExternalScripts

### DIFF
--- a/src/react/external-scripts.tsx
+++ b/src/react/external-scripts.tsx
@@ -107,13 +107,13 @@ export interface ExternalScriptsHandle<Data = unknown> {
  * // Then render ExternalScripts in your root
  * return <ExternalScripts />
  */
-export function ExternalScripts() {
+export function ExternalScripts({ nonce }: { nonce?: string }) {
 	let scripts = useExternalScripts();
 
 	return (
 		<>
 			{scripts.map((props) => {
-				return <ExternalScript key={props.src} {...props} />;
+				return <ExternalScript key={props.src} {...props} nonce={nonce} />;
 			})}
 		</>
 	);


### PR DESCRIPTION
This change allows for a `nonce` value to be passed to the `ExternalScripts` component (similarly to the `Scripts` component from `@remix-run/react`) in order to comply with the `scriptSrc` directive of the page's CSP.

The rationale for allowing this prop specifically is that the `nonce` value is not practical to set in the `ExternalScriptHandle` itself, as it is generated per-request.

Happy to discuss if there's a different recommended way of achieving this :)