### PR TITLE
Make type definition files explicit in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,43 +11,154 @@
 	],
 	"exports": {
 		"./package.json": "./package.json",
-		"./promise": "./build/common/promise.js",
-		"./cache-assets": "./build/client/cache-assets.js",
-		"./cors": "./build/server/cors.js",
-		"./get-client-ip-address": "./build/server/get-client-ip-address.js",
-		"./is-prefetch": "./build/server/is-prefetch.js",
-		"./json-hash": "./build/server/json-hash.js",
-		"./named-action": "./build/server/named-action.js",
-		"./parse-accept-header": "./build/server/parse-accept-header.js",
-		"./preload-route-assets": "./build/server/preload-route-assets.js",
-		"./redirect-back": "./build/server/redirect-back.js",
-		"./respond-to": "./build/server/respond-to.js",
-		"./responses": "./build/server/responses.js",
-		"./rolling-cookie": "./build/server/rolling-cookie.js",
-		"./safe-redirect": "./build/server/safe-redirect.js",
-		"./typed-cookie": "./build/server/typed-cookie.js",
-		"./typed-session": "./build/server/typed-session.js",
-		"./client-only": "./build/react/client-only.js",
-		"./existing-search-params": "./build/react/existing-search-params.js",
-		"./external-scripts": "./build/react/external-scripts.js",
-		"./fetcher-type": "./build/react/fetcher-type.js",
-		"./server-only": "./build/react/server-only.js",
-		"./use-debounce-fetcher": "./build/react/use-debounce-fetcher.js",
-		"./use-debounce-submit": "./build/react/use-debounce-submit.js",
-		"./use-delegated-anchors": "./build/react/use-delegated-anchors.js",
-		"./use-global-navigation-state": "./build/react/use-global-navigation-state.js",
-		"./use-hydrated": "./build/react/use-hydrated.js",
-		"./use-should-hydrate": "./build/react/use-should-hydrate.js",
-		"./sse/server": "./build/server/event-stream.js",
-		"./sse/react": "./build/react/use-event-source.js",
-		"./locales/server": "./build/server/get-client-locales.js",
-		"./locales/react": "./build/react/use-locales.js",
-		"./honeypot/server": "./build/server/honeypot.js",
-		"./honeypot/react": "./build/react/honeypot.js",
-		"./csrf/server": "./build/server/csrf.js",
-		"./csrf/react": "./build/react/authenticity-token.js",
-		"./sec-fetch": "./build/server/sec-fetch.js",
-		"./timers": "./build/common/timers.js"
+		"./promise": {
+			"types": "./build/common/promise.d.ts",
+			"default": "./build/common/promise.js"
+		},
+		"./cache-assets": {
+			"types": "./build/client/cache-assets.d.ts",
+			"default": "./build/client/cache-assets.js"
+		},
+		"./cors": {
+			"types": "./build/server/cors.d.ts",
+			"default": "./build/server/cors.js"
+		},
+		"./get-client-ip-address": {
+			"types": "./build/server/get-client-ip-address.d.ts",
+			"default": "./build/server/get-client-ip-address.js"
+		},
+		"./is-prefetch": {
+			"types": "./build/server/is-prefetch.d.ts",
+			"default": "./build/server/is-prefetch.js"
+		},
+		"./json-hash": {
+			"types": "./build/server/json-hash.d.ts",
+			"default": "./build/server/json-hash.js"
+		},
+		"./named-action": {
+			"types": "./build/server/named-action.d.ts",
+			"default": "./build/server/named-action.js"
+		},
+		"./parse-accept-header": {
+			"types": "./build/server/parse-accept-header.d.ts",
+			"default": "./build/server/parse-accept-header.js"
+		},
+		"./preload-route-assets": {
+			"types": "./build/server/preload-route-assets.d.ts",
+			"default": "./build/server/preload-route-assets.js"
+		},
+		"./redirect-back": {
+			"types": "./build/server/redirect-back.d.ts",
+			"default": "./build/server/redirect-back.js"
+		},
+		"./respond-to": {
+			"types": "./build/server/respond-to.d.ts",
+			"default": "./build/server/respond-to.js"
+		},
+		"./responses": {
+			"types": "./build/server/responses.d.ts",
+			"default": "./build/server/responses.js"
+		},
+		"./rolling-cookie": {
+			"types": "./build/server/rolling-cookie.d.ts",
+			"default": "./build/server/rolling-cookie.js"
+		},
+		"./safe-redirect": {
+			"types": "./build/server/safe-redirect.d.ts",
+			"default": "./build/server/safe-redirect.js"
+		},
+		"./typed-cookie": {
+			"types": "./build/server/typed-cookie.d.ts",
+			"default": "./build/server/typed-cookie.js"
+		},
+		"./typed-session": {
+			"types": "./build/server/typed-session.d.ts",
+			"default": "./build/server/typed-session.js"
+		},
+		"./client-only": {
+			"types": "./build/react/client-only.d.ts",
+			"default": "./build/react/client-only.js"
+		},
+		"./existing-search-params": {
+			"types": "./build/react/existing-search-params.d.ts",
+			"default": "./build/react/existing-search-params.js"
+		},
+		"./external-scripts": {
+			"types": "./build/react/external-scripts.d.ts",
+			"default": "./build/react/external-scripts.js"
+		},
+		"./fetcher-type": {
+			"types": "./build/react/fetcher-type.d.ts",
+			"default": "./build/react/fetcher-type.js"
+		},
+		"./server-only": {
+			"types": "./build/react/server-only.d.ts",
+			"default": "./build/react/server-only.js"
+		},
+		"./use-debounce-fetcher": {
+			"types": "./build/react/use-debounce-fetcher.d.ts",
+			"default": "./build/react/use-debounce-fetcher.js"
+		},
+		"./use-debounce-submit": {
+			"types": "./build/react/use-debounce-submit.d.ts",
+			"default": "./build/react/use-debounce-submit.js"
+		},
+		"./use-delegated-anchors": {
+			"types": "./build/react/use-delegated-anchors.d.ts",
+			"default": "./build/react/use-delegated-anchors.js"
+		},
+		"./use-global-navigation-state": {
+			"types": "./build/react/use-global-navigation-state.d.ts",
+			"default": "./build/react/use-global-navigation-state.js"
+		},
+		"./use-hydrated": {
+			"types": "./build/react/use-hydrated.d.ts",
+			"default": "./build/react/use-hydrated.js"
+		},
+		"./use-should-hydrate": {
+			"types": "./build/react/use-should-hydrate.d.ts",
+			"default": "./build/react/use-should-hydrate.js"
+		},
+		"./sse/server": {
+			"types": "./build/server/event-stream.d.ts",
+			"default": "./build/server/event-stream.js"
+		},
+		"./sse/react": {
+			"types": "./build/react/use-event-source.d.ts",
+			"default": "./build/react/use-event-source.js"
+		},
+		"./locales/server": {
+			"types": "./build/server/get-client-locales.d.ts",
+			"default": "./build/server/get-client-locales.js"
+		},
+		"./locales/react": {
+			"types": "./build/react/use-locales.d.ts",
+			"default": "./build/react/use-locales.js"
+		},
+		"./honeypot/server": {
+			"types": "./build/server/honeypot.d.ts",
+			"default": "./build/server/honeypot.js"
+		},
+		"./honeypot/react": {
+			"types": "./build/react/honeypot.d.ts",
+			"default": "./build/react/honeypot.js"
+		},
+		"./csrf/server": {
+			"types": "./build/server/csrf.d.ts",
+			"default": "./build/server/csrf.js"
+		},
+		"./csrf/react": {
+			"types": "./build/react/authenticity-token.d.ts",
+			"default": "./build/react/authenticity-token.js"
+		},
+		"./sec-fetch": {
+			"types": "./build/server/sec-fetch.d.ts",
+			"default": "./build/server/sec-fetch.js"
+		},
+		"./timers": {
+			"types": "./build/common/timers.d.ts",
+			"default": "./build/common/timers.js"
+		}
 	},
 	"sideEffects": false,
 	"scripts": {


### PR DESCRIPTION
`.d.ts` files have already been published to npm, but tsc sometimes does not use them by `import { something } from "remix-utils/something"`.
This PR adds them to `package.json` and allow tsc to use them *uncoditionally*.

There is no "TS" badge in https://www.npmjs.com/package/remix-utils now, but one may be added thanks to this PR.