### PR TITLE
[promise] Fix types for using .then() with promiseHash

### DIFF
--- a/src/common/promise.ts
+++ b/src/common/promise.ts
@@ -3,9 +3,9 @@
  */
 export type PromiseHash = Record<string, Promise<unknown>>;
 
-export type AwaitedPromiseHash<Hash extends PromiseHash> = {
+export type AwaitedPromiseHash<Hash> = Hash extends PromiseHash ? {
 	[Key in keyof Hash]: Awaited<Hash[Key]>;
-};
+} : never;
 
 /**
  * Get a hash of promises and await them all.
@@ -35,7 +35,7 @@ export type AwaitedPromiseHash<Hash extends PromiseHash> = {
  *   );
  * }
  */
-export async function promiseHash<Hash extends PromiseHash>(
+export async function promiseHash<Hash extends object>(
 	hash: Hash,
 ): Promise<AwaitedPromiseHash<Hash>> {
 	return Object.fromEntries(


### PR DESCRIPTION
Using `.then()` in a value passed to `promiseHash()` produces `Promise<unknown>`. This should fix that up so that it properly infers the type.

I'm going to be 100% honest, I'm not entirely sure as to why this works and the existing type constraint _doesn't_. But it seems to do what I expect.

It would be awesome if this could also get integrated into the v7 line for use with `remix@2` as well 🙏 