### PR TITLE
Expose promise from `useDebouncedSubmit` to align with `useSubmit`

### DIFF
--- a/src/react/use-debounce-submit.ts
+++ b/src/react/use-debounce-submit.ts
@@ -44,9 +44,11 @@ export function useDebounceSubmit() {
 				return originalSubmit(target, options);
 			}
 
-			timeoutRef.current = setTimeout(() => {
-				originalSubmit(target, options);
-			}, options.debounceTimeout);
+			return new Promise<void>((resolve) => {
+				timeoutRef.current = setTimeout(() => {
+					resolve(originalSubmit(target, options));
+				}, options.debounceTimeout);
+			});
 		},
 		[originalSubmit],
 	);


### PR DESCRIPTION
Currently `useDebounceSubmit` has a bit of a [Zalg̯o issuḙ͖](https://blog.izs.me/2013/08/designing-apis-for-asynchrony/) issue, in that it sometimes returns a `Promise` and sometimes doesn't.

This incidentally makes the return type of the returned `submit` function `Promise<void> | void`, which causes issues when attempting to pass the submit handler to a prop that's expecting something compatible with the function returned by `useSubmit`.

Instead, it should return a Promise that resolves when the debounced `submit()` function also resolves.