### PR TITLE
Add `secureHeaders` middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -2675,14 +2675,15 @@ import { jwkAuthMiddleware } from "~/middleware/jwk-auth";
 export const unstable_middleware = [jwkAuthMiddleware];
 ```
 
-#### Secure headers Middleware
+#### Secure Headers Middleware
 
-The secure headers middleware simplifies the setup of security headers. Inspired in part by the version from [hono secure headers middleware](https://hono.dev/docs/middleware/builtin/secure-headers).
+The secure headers middleware simplifies the setup of security headers. Inspired in part by the version from [Hono `secureHeaders` middleware](https://hono.dev/docs/middleware/builtin/secure-headers).
 
 ```ts
 import { unstable_createSecureHeadersMiddleware } from "remix-utils/middleware/secure-headers";
 
-export const [secureHeadersMiddleware] = unstable_createSecureHeadersMiddleware();
+export const [secureHeadersMiddleware] =
+  unstable_createSecureHeadersMiddleware();
 ```
 
 To use it, you need to add it to the `unstable_middleware` array in your `app/root.tsx` file.
@@ -2694,9 +2695,30 @@ export const unstable_middleware = [secureHeadersMiddleware];
 
 Now, every response will have the security header responses.
 
-The secure headers middleware middleware can be customized by passing an options object to the `unstable_createSecureHeadersMiddleware` function.
+## Supported Options
 
-The options let's you configure the headers key values. [More info here](https://hono.dev/docs/middleware/builtin/secure-headers#supported-options) .
+Each option corresponds to the following Header Key-Value pairs.
+
+| Option                          | Header                                                                                                                                         | Value                                                                      | Default    |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ---------- |
+| -                               | X-Powered-By                                                                                                                                   | (Delete Header)                                                            | True       |
+| contentSecurityPolicy           | [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)                                                               | Usage: [Setting Content-Security-Policy](#setting-content-security-policy) | No Setting |
+| contentSecurityPolicyReportOnly | [Content-Security-Policy-Report-Only](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only)           | Usage: [Setting Content-Security-Policy](#setting-content-security-policy) | No Setting |
+| crossOriginEmbedderPolicy       | [Cross-Origin-Embedder-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy)                         | require-corp                                                               | **False**  |
+| crossOriginResourcePolicy       | [Cross-Origin-Resource-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy)                         | same-origin                                                                | True       |
+| crossOriginOpenerPolicy         | [Cross-Origin-Opener-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy)                             | same-origin                                                                | True       |
+| originAgentCluster              | [Origin-Agent-Cluster](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin-Agent-Cluster)                                         | ?1                                                                         | True       |
+| referrerPolicy                  | [Referrer-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)                                                   | no-referrer                                                                | True       |
+| reportingEndpoints              | [Reporting-Endpoints](https://www.w3.org/TR/reporting-1/#header)                                                                               | Usage: [Setting Content-Security-Policy](#setting-content-security-policy) | No Setting |
+| reportTo                        | [Report-To](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to)                                       | Usage: [Setting Content-Security-Policy](#setting-content-security-policy) | No Setting |
+| strictTransportSecurity         | [Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)                               | max-age=15552000; includeSubDomains                                        | True       |
+| xContentTypeOptions             | [X-Content-Type-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options)                                     | nosniff                                                                    | True       |
+| xDnsPrefetchControl             | [X-DNS-Prefetch-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control)                                     | off                                                                        | True       |
+| xDownloadOptions                | [X-Download-Options](https://learn.microsoft.com/en-us/archive/blogs/ie/ie8-security-part-v-comprehensive-protection#mime-handling-force-save) | noopen                                                                     | True       |
+| xFrameOptions                   | [X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options)                                                   | SAMEORIGIN                                                                 | True       |
+| xPermittedCrossDomainPolicies   | [X-Permitted-Cross-Domain-Policies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Permitted-Cross-Domain-Policies)               | none                                                                       | True       |
+| xXssProtection                  | [X-XSS-Protection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection)                                                 | 0                                                                          | True       |
+| permissionPolicy                | [Permissions-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy)                                             | Usage: [Setting Permission-Policy](#setting-permission-policy)             | No Setting |
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -2695,7 +2695,7 @@ export const unstable_middleware = [secureHeadersMiddleware];
 
 Now, every response will have the security header responses.
 
-## Supported Options
+##### Supported Options
 
 Each option corresponds to the following Header Key-Value pairs.
 
@@ -2719,6 +2719,30 @@ Each option corresponds to the following Header Key-Value pairs.
 | xPermittedCrossDomainPolicies   | [X-Permitted-Cross-Domain-Policies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Permitted-Cross-Domain-Policies)               | none                                                                       | True       |
 | xXssProtection                  | [X-XSS-Protection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection)                                                 | 0                                                                          | True       |
 | permissionPolicy                | [Permissions-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy)                                             | Usage: [Setting Permission-Policy](#setting-permission-policy)             | No Setting |
+
+##### Setting Permission-Policy
+
+The Permission-Policy header allows you to control which features and APIs can be used in the browser. Here's an example of how to set it:
+
+```ts
+export const [secureHeadersMiddleware] = unstable_createSecureHeadersMiddleware(
+  {
+    permissionsPolicy: {
+      fullscreen: ["self"], // fullscreen=(self)
+      bluetooth: ["none"], // bluetooth=(none)
+      payment: ["self", "https://example.com"], // payment=(self "https://example.com")
+      syncXhr: [], // sync-xhr=()
+      camera: false, // camera=none
+      microphone: true, // microphone=*
+      geolocation: ["*"], // geolocation=*
+      usb: ["self", "https://a.example.com", "https://b.example.com"], // usb=(self "https://a.example.com" "https://b.example.com")
+      accelerometer: ["https://*.example.com"], // accelerometer=("https://*.example.com")
+      gyroscope: ["src"], // gyroscope=(src)
+      magnetometer: ["https://a.example.com", "https://b.example.com"], // magnetometer=("https://a.example.com" "https://b.example.com")
+    },
+  }
+);
+```
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -2860,54 +2860,9 @@ export const unstable_middleware = [secureHeadersMiddleware];
 
 Now, every response will have the security header responses.
 
-##### Supported Options
+The secure headers middleware middleware can be customized by passing an options object to the `unstable_createSecureHeadersMiddleware` function.
 
-Each option corresponds to the following Header Key-Value pairs.
-
-| Option                          | Header                                                                                                                                         | Value                                                                      | Default    |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ---------- |
-| -                               | X-Powered-By                                                                                                                                   | (Delete Header)                                                            | True       |
-| contentSecurityPolicy           | [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)                                                               | Usage: [Setting Content-Security-Policy](#setting-content-security-policy) | No Setting |
-| contentSecurityPolicyReportOnly | [Content-Security-Policy-Report-Only](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only)           | Usage: [Setting Content-Security-Policy](#setting-content-security-policy) | No Setting |
-| crossOriginEmbedderPolicy       | [Cross-Origin-Embedder-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy)                         | require-corp                                                               | **False**  |
-| crossOriginResourcePolicy       | [Cross-Origin-Resource-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy)                         | same-origin                                                                | True       |
-| crossOriginOpenerPolicy         | [Cross-Origin-Opener-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy)                             | same-origin                                                                | True       |
-| originAgentCluster              | [Origin-Agent-Cluster](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin-Agent-Cluster)                                         | ?1                                                                         | True       |
-| referrerPolicy                  | [Referrer-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)                                                   | no-referrer                                                                | True       |
-| reportingEndpoints              | [Reporting-Endpoints](https://www.w3.org/TR/reporting-1/#header)                                                                               | Usage: [Setting Content-Security-Policy](#setting-content-security-policy) | No Setting |
-| reportTo                        | [Report-To](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to)                                       | Usage: [Setting Content-Security-Policy](#setting-content-security-policy) | No Setting |
-| strictTransportSecurity         | [Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)                               | max-age=15552000; includeSubDomains                                        | True       |
-| xContentTypeOptions             | [X-Content-Type-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options)                                     | nosniff                                                                    | True       |
-| xDnsPrefetchControl             | [X-DNS-Prefetch-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control)                                     | off                                                                        | True       |
-| xDownloadOptions                | [X-Download-Options](https://learn.microsoft.com/en-us/archive/blogs/ie/ie8-security-part-v-comprehensive-protection#mime-handling-force-save) | noopen                                                                     | True       |
-| xFrameOptions                   | [X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options)                                                   | SAMEORIGIN                                                                 | True       |
-| xPermittedCrossDomainPolicies   | [X-Permitted-Cross-Domain-Policies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Permitted-Cross-Domain-Policies)               | none                                                                       | True       |
-| xXssProtection                  | [X-XSS-Protection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection)                                                 | 0                                                                          | True       |
-| permissionPolicy                | [Permissions-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy)                                             | Usage: [Setting Permission-Policy](#setting-permission-policy)             | No Setting |
-
-##### Setting Permission-Policy
-
-The Permission-Policy header allows you to control which features and APIs can be used in the browser. Here's an example of how to set it:
-
-```ts
-export const [secureHeadersMiddleware] = unstable_createSecureHeadersMiddleware(
-  {
-    permissionsPolicy: {
-      fullscreen: ["self"], // fullscreen=(self)
-      bluetooth: ["none"], // bluetooth=(none)
-      payment: ["self", "https://example.com"], // payment=(self "https://example.com")
-      syncXhr: [], // sync-xhr=()
-      camera: false, // camera=none
-      microphone: true, // microphone=*
-      geolocation: ["*"], // geolocation=*
-      usb: ["self", "https://a.example.com", "https://b.example.com"], // usb=(self "https://a.example.com" "https://b.example.com")
-      accelerometer: ["https://*.example.com"], // accelerometer=("https://*.example.com")
-      gyroscope: ["src"], // gyroscope=(src)
-      magnetometer: ["https://a.example.com", "https://b.example.com"], // magnetometer=("https://a.example.com" "https://b.example.com")
-    },
-  }
-);
-```
+The options let's you configure the headers key values. [More info here](https://hono.dev/docs/middleware/builtin/secure-headers#supported-options) .
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -2696,8 +2696,6 @@ Now, every response will have the security header responses.
 
 The secure headers middleware middleware can be customized by passing an options object to the `unstable_createSecureHeadersMiddleware` function.
 
----
-
 The options let's you configure the headers key values. [More info here](https://hono.dev/docs/middleware/builtin/secure-headers#supported-options) .
 
 ## Author

--- a/README.md
+++ b/README.md
@@ -2675,6 +2675,31 @@ import { jwkAuthMiddleware } from "~/middleware/jwk-auth";
 export const unstable_middleware = [jwkAuthMiddleware];
 ```
 
+#### Secure headers Middleware
+
+The secure headers middleware simplifies the setup of security headers. Inspired in part by the version from [hono secure headers middleware](https://hono.dev/docs/middleware/builtin/secure-headers).
+
+```ts
+import { unstable_createSecureHeadersMiddleware } from "remix-utils/middleware/secure-headers";
+
+export const [secureHeadersMiddleware] = unstable_createSecureHeadersMiddleware();
+```
+
+To use it, you need to add it to the `unstable_middleware` array in your `app/root.tsx` file.
+
+```ts
+import { secureHeadersMiddleware } from "~/middleware/secure-headers.server";
+export const unstable_middleware = [secureHeadersMiddleware];
+```
+
+Now, every response will have the security header responses.
+
+The secure headers middleware middleware can be customized by passing an options object to the `unstable_createSecureHeadersMiddleware` function.
+
+---
+
+The options let's you configure the headers key values. [More info here](https://hono.dev/docs/middleware/builtin/secure-headers#supported-options) .
+
 ## Author
 
 - [Sergio Xalambrí](https://sergiodxa.com)

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
 			"types": "./build/server/middleware/request-id.d.ts",
 			"default": "./build/server/middleware/request-id.js"
 		},
+		"./middleware/secure-headers": {
+			"types": "./build/server/middleware/secure-headers.d.ts",
+			"default": "./build/server/middleware/secure-headers.js"
+		},
 		"./middleware/server-timing": {
 			"types": "./build/server/middleware/server-timing.d.ts",
 			"default": "./build/server/middleware/server-timing.js"

--- a/src/server/middleware/secure-headers.test.ts
+++ b/src/server/middleware/secure-headers.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, test } from "bun:test";
+import { unstable_createSecureHeadersMiddleware } from "./secure-headers";
+import { runMiddleware } from "./test-helper";
+
+describe(unstable_createSecureHeadersMiddleware.name, () => {
+	test("returns a middleware function", () => {
+		let [middleware] = unstable_createSecureHeadersMiddleware();
+		expect(middleware).toBeFunction();
+	});
+
+	test("the middleware should add the default headers", async () => {
+		let [middleware] = unstable_createSecureHeadersMiddleware();
+
+		let response = await runMiddleware(middleware);
+
+		expect(response).toBeInstanceOf(Response);
+		expect(response.headers.get("X-Frame-Options")).toEqual("SAMEORIGIN");
+		expect(response.headers.get("Strict-Transport-Security")).toEqual(
+			"max-age=15552000; includeSubDomains",
+		);
+		expect(response.headers.get("X-Download-Options")).toEqual("noopen");
+		expect(response.headers.get("X-XSS-Protection")).toEqual("0");
+		expect(response.headers.get("X-Powered-By")).toBeNull();
+		expect(response.headers.get("X-DNS-Prefetch-Control")).toEqual("off");
+		expect(response.headers.get("X-Content-Type-Options")).toEqual("nosniff");
+		expect(response.headers.get("Referrer-Policy")).toEqual("no-referrer");
+		expect(response.headers.get("X-Permitted-Cross-Domain-Policies")).toEqual(
+			"none",
+		);
+		expect(response.headers.get("Cross-Origin-Resource-Policy")).toEqual(
+			"same-origin",
+		);
+		expect(response.headers.get("Cross-Origin-Opener-Policy")).toEqual(
+			"same-origin",
+		);
+		expect(response.headers.get("Origin-Agent-Cluster")).toEqual("?1");
+		expect(response.headers.get("Permissions-Policy")).toBeNull();
+		expect(response.headers.get("Content-Security-Policy")).toBeFalsy();
+		expect(
+			response.headers.get("Content-Security-Policy-ReportOnly"),
+		).toBeFalsy();
+	});
+
+	test("all headers enabled", async () => {
+		let [middleware] = unstable_createSecureHeadersMiddleware({
+			contentSecurityPolicy: {
+				defaultSrc: ["'self'"],
+			},
+			contentSecurityPolicyReportOnly: {
+				defaultSrc: ["'self'"],
+			},
+			crossOriginEmbedderPolicy: true,
+			permissionsPolicy: {
+				camera: [],
+			},
+		});
+
+		let response = await runMiddleware(middleware);
+
+		expect(response).not.toBeNull();
+		expect(response.status).toBe(200);
+		expect(response.headers.get("X-Frame-Options")).toEqual("SAMEORIGIN");
+		expect(response.headers.get("Strict-Transport-Security")).toEqual(
+			"max-age=15552000; includeSubDomains",
+		);
+		expect(response.headers.get("X-Download-Options")).toEqual("noopen");
+		expect(response.headers.get("X-XSS-Protection")).toEqual("0");
+		expect(response.headers.get("X-Powered-By")).toBeNull();
+		expect(response.headers.get("X-DNS-Prefetch-Control")).toEqual("off");
+		expect(response.headers.get("X-Content-Type-Options")).toEqual("nosniff");
+		expect(response.headers.get("Referrer-Policy")).toEqual("no-referrer");
+		expect(response.headers.get("X-Permitted-Cross-Domain-Policies")).toEqual(
+			"none",
+		);
+		expect(response.headers.get("Cross-Origin-Resource-Policy")).toEqual(
+			"same-origin",
+		);
+		expect(response.headers.get("Cross-Origin-Opener-Policy")).toEqual(
+			"same-origin",
+		);
+		expect(response.headers.get("Origin-Agent-Cluster")).toEqual("?1");
+		expect(response.headers.get("Cross-Origin-Embedder-Policy")).toEqual(
+			"require-corp",
+		);
+		expect(response.headers.get("Permissions-Policy")).toEqual("camera=()");
+		expect(response.headers.get("Content-Security-Policy")).toEqual(
+			"default-src 'self'",
+		);
+		expect(response.headers.get("Content-Security-Policy-Report-Only")).toEqual(
+			"default-src 'self'",
+		);
+	});
+
+	test("specific headers disabled", async () => {
+		let [middleware] = unstable_createSecureHeadersMiddleware({
+			xFrameOptions: false,
+			xXssProtection: false,
+		});
+
+		let res = await runMiddleware(middleware);
+
+		expect(res.headers.get("X-Frame-Options")).toBeNull();
+		expect(res.headers.get("Strict-Transport-Security")).toEqual(
+			"max-age=15552000; includeSubDomains",
+		);
+		expect(res.headers.get("X-Download-Options")).toEqual("noopen");
+		expect(res.headers.get("X-XSS-Protection")).toBeNull();
+		expect(res.headers.get("X-Powered-By")).toBeNull();
+		expect(res.headers.get("X-DNS-Prefetch-Control")).toEqual("off");
+		expect(res.headers.get("X-Content-Type-Options")).toEqual("nosniff");
+		expect(res.headers.get("Referrer-Policy")).toEqual("no-referrer");
+		expect(res.headers.get("X-Permitted-Cross-Domain-Policies")).toEqual(
+			"none",
+		);
+		expect(res.headers.get("Cross-Origin-Resource-Policy")).toEqual(
+			"same-origin",
+		);
+		expect(res.headers.get("Cross-Origin-Opener-Policy")).toEqual(
+			"same-origin",
+		);
+		expect(res.headers.get("Permissions-Policy")).toBeNull();
+		expect(res.headers.get("Origin-Agent-Cluster")).toEqual("?1");
+	});
+
+	test("should use custom value when overridden", async () => {
+		let [middleware] = unstable_createSecureHeadersMiddleware({
+			strictTransportSecurity: "max-age=31536000; includeSubDomains; preload;",
+			xFrameOptions: "DENY",
+			xXssProtection: "1",
+		});
+
+		let res = await runMiddleware(middleware);
+
+		expect(res.headers.get("Strict-Transport-Security")).toEqual(
+			"max-age=31536000; includeSubDomains; preload;",
+		);
+		expect(res.headers.get("X-FRAME-OPTIONS")).toEqual("DENY");
+		expect(res.headers.get("X-XSS-Protection")).toEqual("1");
+	});
+
+	test("should set Permission-Policy header correctly", async () => {
+		let [middleware] = unstable_createSecureHeadersMiddleware({
+			permissionsPolicy: {
+				fullscreen: ["self"],
+				bluetooth: ["none"],
+				payment: ["self", "example.com"],
+				syncXhr: [],
+				camera: false,
+				microphone: true,
+				geolocation: ["*"],
+				usb: ["self", "https://a.example.com", "https://b.example.com"],
+				accelerometer: ["https://*.example.com"],
+				gyroscope: ["src"],
+				magnetometer: ["https://a.example.com", "https://b.example.com"],
+			},
+		});
+
+		let res = await runMiddleware(middleware);
+
+		expect(res.headers.get("Permissions-Policy")).toEqual(
+			'fullscreen=(self), bluetooth=none, payment=(self "example.com"), sync-xhr=(), camera=none, microphone=*, ' +
+				'geolocation=*, usb=(self "https://a.example.com" "https://b.example.com"), ' +
+				'accelerometer=("https://*.example.com"), gyroscope=(src), ' +
+				'magnetometer=("https://a.example.com" "https://b.example.com")',
+		);
+	});
+
+	describe.each([
+		{
+			cspSettingName: "contentSecurityPolicy",
+			cspHeaderName: "Content-Security-Policy",
+		},
+		{
+			cspSettingName: "contentSecurityPolicyReportOnly",
+			cspHeaderName: "Content-Security-Policy-Report-Only",
+		},
+	])("CSP Setting ($cspSettingName)", ({ cspSettingName, cspHeaderName }) => {
+		test("CSP Setting", async () => {
+			let [middleware] = unstable_createSecureHeadersMiddleware({
+				[cspSettingName]: {
+					defaultSrc: ["'self'"],
+					baseUri: ["'self'"],
+					fontSrc: ["'self'", "https:", "data:"],
+					frameAncestors: ["'self'"],
+					imgSrc: ["'self'", "data:"],
+					objectSrc: ["'none'"],
+					scriptSrc: ["'self'"],
+					scriptSrcAttr: ["'none'"],
+					styleSrc: ["'self'", "https:", "'unsafe-inline'"],
+				},
+			});
+
+			let res = await runMiddleware(middleware);
+
+			expect(res.headers.get(cspHeaderName)).toEqual(
+				"default-src 'self'; base-uri 'self'; font-src 'self' https: data:; frame-ancestors 'self'; img-src 'self' data:; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self' https: 'unsafe-inline'",
+			);
+		});
+
+		test("CSP Setting one only", async () => {
+			let [middleware] = unstable_createSecureHeadersMiddleware({
+				[cspSettingName]: {
+					defaultSrc: ["'self'"],
+				},
+			});
+
+			let res = await runMiddleware(middleware);
+
+			expect(res.headers.get(cspHeaderName)).toEqual("default-src 'self'");
+		});
+
+		test("No CSP Setting", async () => {
+			let [middleware] = unstable_createSecureHeadersMiddleware({
+				[cspSettingName]: {},
+			});
+
+			let res = await runMiddleware(middleware);
+
+			expect(res.headers.get(cspHeaderName)).toEqual("");
+		});
+
+		test("CSP with reportTo 0", async () => {
+			let [middleware] = unstable_createSecureHeadersMiddleware({
+				reportingEndpoints: [
+					{
+						name: "endpoint-1",
+						url: "https://example.com/reports",
+					},
+				],
+				[cspSettingName]: {
+					defaultSrc: ["'self'"],
+					reportTo: "endpoint-1",
+				},
+			});
+
+			let res = await runMiddleware(middleware);
+
+			expect(res.headers.get("Reporting-Endpoints")).toEqual(
+				'endpoint-1="https://example.com/reports"',
+			);
+			expect(res.headers.get(cspHeaderName)).toEqual(
+				"default-src 'self'; report-to endpoint-1",
+			);
+		});
+		test("CSP with reportTo 1", async () => {
+			let [middleware] = unstable_createSecureHeadersMiddleware({
+				reportTo: [
+					{
+						group: "endpoint-1",
+						max_age: 10886400,
+						endpoints: [{ url: "https://example.com/reports" }],
+					},
+				],
+				[cspSettingName]: {
+					defaultSrc: ["'self'"],
+					reportTo: "endpoint-1",
+				},
+			});
+			let res = await runMiddleware(middleware);
+
+			expect(res.headers.get("Report-To")).toEqual(
+				'{"group":"endpoint-1","max_age":10886400,"endpoints":[{"url":"https://example.com/reports"}]}',
+			);
+			expect(res.headers.get(cspHeaderName)).toEqual(
+				"default-src 'self'; report-to endpoint-1",
+			);
+		});
+
+		test("CSP with reportTo 2", async () => {
+			let [middleware] = unstable_createSecureHeadersMiddleware({
+				reportTo: [
+					{
+						group: "g1",
+						max_age: 10886400,
+						endpoints: [
+							{ url: "https://a.example.com/reports" },
+							{ url: "https://b.example.com/reports" },
+						],
+					},
+					{
+						group: "g2",
+						max_age: 10886400,
+						endpoints: [
+							{ url: "https://c.example.com/reports" },
+							{ url: "https://d.example.com/reports" },
+						],
+					},
+				],
+				[cspSettingName]: {
+					defaultSrc: ["'self'"],
+					reportTo: "g2",
+				},
+			});
+
+			let res = await runMiddleware(middleware);
+
+			expect(res.headers.get("Report-To")).toEqual(
+				'{"group":"g1","max_age":10886400,"endpoints":[{"url":"https://a.example.com/reports"},{"url":"https://b.example.com/reports"}]}, {"group":"g2","max_age":10886400,"endpoints":[{"url":"https://c.example.com/reports"},{"url":"https://d.example.com/reports"}]}',
+			);
+			expect(res.headers.get(cspHeaderName)).toEqual(
+				"default-src 'self'; report-to g2",
+			);
+		});
+
+		test("CSP with reportTo 3", async () => {
+			let [middleware] = unstable_createSecureHeadersMiddleware({
+				reportingEndpoints: [
+					{
+						name: "e1",
+						url: "https://a.example.com/reports",
+					},
+					{
+						name: "e2",
+						url: "https://b.example.com/reports",
+					},
+				],
+				[cspSettingName]: {
+					defaultSrc: ["'self'"],
+					reportTo: "e1",
+				},
+			});
+
+			let res = await runMiddleware(middleware);
+
+			expect(res.headers.get("Reporting-Endpoints")).toEqual(
+				'e1="https://a.example.com/reports", e2="https://b.example.com/reports"',
+			);
+			expect(res.headers.get(cspHeaderName)).toEqual(
+				"default-src 'self'; report-to e1",
+			);
+		});
+	});
+});

--- a/src/server/middleware/secure-headers.ts
+++ b/src/server/middleware/secure-headers.ts
@@ -116,7 +116,8 @@ type PermissionsPolicyDirective =
 	| ExperimentalFeatures;
 
 /**
- * These features have been declared in a published version of the respective specification.
+ * These features have been declared in a published version of the respective
+ * specification.
  */
 type StandardizedFeatures =
 	| "accelerometer"
@@ -167,7 +168,8 @@ type StandardizedFeatures =
 	| "xrSpatialTracking";
 
 /**
- * These features have been proposed, but the definitions have not yet been integrated into their respective specs.
+ * These features have been proposed, but the definitions have not yet been
+ * integrated into their respective specs.
  */
 type ProposedFeatures =
 	| "clipboardRead"
@@ -177,7 +179,8 @@ type ProposedFeatures =
 	| "speakerSelection";
 
 /**
- * These features generally have an explainer only, but may be available for experimentation by web developers.
+ * These features generally have an explainer only, but may be available for
+ * experimentation by web developers.
  */
 type ExperimentalFeatures =
 	| "allScreensCapture"
@@ -256,7 +259,7 @@ type HeadersMap = {
 	];
 };
 
-let HEADERS_MAP: HeadersMap = {
+const HEADERS_MAP: HeadersMap = {
 	crossOriginEmbedderPolicy: ["Cross-Origin-Embedder-Policy", "require-corp"],
 	crossOriginResourcePolicy: ["Cross-Origin-Resource-Policy", "same-origin"],
 	crossOriginOpenerPolicy: ["Cross-Origin-Opener-Policy", "same-origin"],
@@ -274,7 +277,7 @@ let HEADERS_MAP: HeadersMap = {
 	xXssProtection: ["X-XSS-Protection", "0"],
 };
 
-let DEFAULT_OPTIONS: unstable_createSecureHeadersMiddleware.SecureHeadersOptions =
+const DEFAULT_OPTIONS: unstable_createSecureHeadersMiddleware.SecureHeadersOptions =
 	{
 		crossOriginEmbedderPolicy: false,
 		crossOriginResourcePolicy: true,
@@ -385,15 +388,4 @@ function setHeaders(response: Response, headersToSet: Array<[string, string]>) {
 	for (let [header, value] of headersToSet) {
 		response.headers.set(header, value);
 	}
-}
-
-// This approach is written in MDN.
-// btoa does not support utf-8 characters. So we need a little bit hack.
-export function encodeBase64(buf: ArrayBufferLike): string {
-	let binary = "";
-	let bytes = new Uint8Array(buf);
-	for (let byte of bytes) {
-		binary += String.fromCharCode(byte);
-	}
-	return btoa(binary);
 }

--- a/src/server/middleware/secure-headers.ts
+++ b/src/server/middleware/secure-headers.ts
@@ -1,0 +1,399 @@
+import type { unstable_MiddlewareFunction } from "react-router";
+
+/**
+ * Secure Headers Middleware for React-router.
+ *
+ * @param {Partial<SecureHeadersOptions>} [customOptions] - The options for the secure headers middleware.
+ * @param {ContentSecurityPolicyOptions} [customOptions.contentSecurityPolicy] - Settings for the Content-Security-Policy header.
+ * @param {ContentSecurityPolicyOptions} [customOptions.contentSecurityPolicyReportOnly] - Settings for the Content-Security-Policy-Report-Only header.
+ * @param {overridableHeader} [customOptions.crossOriginEmbedderPolicy=false] - Settings for the Cross-Origin-Embedder-Policy header.
+ * @param {overridableHeader} [customOptions.crossOriginResourcePolicy=true] - Settings for the Cross-Origin-Resource-Policy header.
+ * @param {overridableHeader} [customOptions.crossOriginOpenerPolicy=true] - Settings for the Cross-Origin-Opener-Policy header.
+ * @param {overridableHeader} [customOptions.originAgentCluster=true] - Settings for the Origin-Agent-Cluster header.
+ * @param {overridableHeader} [customOptions.referrerPolicy=true] - Settings for the Referrer-Policy header.
+ * @param {ReportingEndpointOptions[]} [customOptions.reportingEndpoints] - Settings for the Reporting-Endpoints header.
+ * @param {ReportToOptions[]} [customOptions.reportTo] - Settings for the Report-To header.
+ * @param {overridableHeader} [customOptions.strictTransportSecurity=true] - Settings for the Strict-Transport-Security header.
+ * @param {overridableHeader} [customOptions.xContentTypeOptions=true] - Settings for the X-Content-Type-Options header.
+ * @param {overridableHeader} [customOptions.xDnsPrefetchControl=true] - Settings for the X-DNS-Prefetch-Control header.
+ * @param {overridableHeader} [customOptions.xDownloadOptions=true] - Settings for the X-Download-Options header.
+ * @param {overridableHeader} [customOptions.xFrameOptions=true] - Settings for the X-Frame-Options header.
+ * @param {overridableHeader} [customOptions.xPermittedCrossDomainPolicies=true] - Settings for the X-Permitted-Cross-Domain-Policies header.
+ * @param {overridableHeader} [customOptions.xXssProtection=true] - Settings for the X-XSS-Protection header.
+ * @param {boolean} [customOptions.removePoweredBy=true] - Settings for remove X-Powered-By header.
+ * @param {PermissionsPolicyOptions} [customOptions.permissionsPolicy] - Settings for the Permissions-Policy header.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ */
+export function unstable_createSecureHeadersMiddleware(
+	customOptions?: unstable_createSecureHeadersMiddleware.SecureHeadersOptions,
+): unstable_createSecureHeadersMiddleware.ReturnType {
+	let options = { ...DEFAULT_OPTIONS, ...customOptions };
+	let headersToSet = getFilteredHeaders(options);
+
+	if (options.contentSecurityPolicy) {
+		let value = getCSPDirectives(options.contentSecurityPolicy);
+		headersToSet.push(["Content-Security-Policy", value]);
+	}
+
+	if (options.contentSecurityPolicyReportOnly) {
+		let value = getCSPDirectives(options.contentSecurityPolicyReportOnly);
+		headersToSet.push(["Content-Security-Policy-Report-Only", value]);
+	}
+
+	if (
+		options.permissionsPolicy &&
+		Object.keys(options.permissionsPolicy).length > 0
+	) {
+		headersToSet.push([
+			"Permissions-Policy",
+			getPermissionsPolicyDirectives(options.permissionsPolicy),
+		]);
+	}
+
+	if (options.reportingEndpoints) {
+		headersToSet.push([
+			"Reporting-Endpoints",
+			getReportingEndpoints(options.reportingEndpoints),
+		]);
+	}
+
+	if (options.reportTo) {
+		headersToSet.push(["Report-To", getReportToOptions(options.reportTo)]);
+	}
+
+	return [
+		async function secureHeaders(_, next) {
+			// should evaluate callbacks before next()
+			// some callback calls ctx.set() for embedding nonce to the page
+			let response = await next();
+			setHeaders(response, headersToSet);
+
+			if (options?.removePoweredBy) {
+				response.headers.delete("X-Powered-By");
+			}
+			return response;
+		},
+	];
+}
+
+export namespace unstable_createSecureHeadersMiddleware {
+	export interface SecureHeadersOptions {
+		contentSecurityPolicy?: ContentSecurityPolicyOptions;
+		contentSecurityPolicyReportOnly?: ContentSecurityPolicyOptions;
+		crossOriginEmbedderPolicy?: overridableHeader;
+		crossOriginResourcePolicy?: overridableHeader;
+		crossOriginOpenerPolicy?: overridableHeader;
+		originAgentCluster?: overridableHeader;
+		referrerPolicy?: overridableHeader;
+		reportingEndpoints?: Array<ReportingEndpointOptions>;
+		reportTo?: Array<ReportToOptions>;
+		strictTransportSecurity?: overridableHeader;
+		xContentTypeOptions?: overridableHeader;
+		xDnsPrefetchControl?: overridableHeader;
+		xDownloadOptions?: overridableHeader;
+		xFrameOptions?: overridableHeader;
+		xPermittedCrossDomainPolicies?: overridableHeader;
+		xXssProtection?: overridableHeader;
+		removePoweredBy?: boolean;
+		permissionsPolicy?: PermissionsPolicyOptions;
+	}
+
+	export type ReturnType = [unstable_MiddlewareFunction<Response>];
+
+	export interface Logger {
+		error(...message: string[]): void;
+		warn(...message: string[]): void;
+		info(...message: string[]): void;
+		debug(...message: string[]): void;
+	}
+}
+
+// https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md
+
+type PermissionsPolicyDirective =
+	| StandardizedFeatures
+	| ProposedFeatures
+	| ExperimentalFeatures;
+
+/**
+ * These features have been declared in a published version of the respective specification.
+ */
+type StandardizedFeatures =
+	| "accelerometer"
+	| "ambientLightSensor"
+	| "attributionReporting"
+	| "autoplay"
+	| "battery"
+	| "bluetooth"
+	| "camera"
+	| "chUa"
+	| "chUaArch"
+	| "chUaBitness"
+	| "chUaFullVersion"
+	| "chUaFullVersionList"
+	| "chUaMobile"
+	| "chUaModel"
+	| "chUaPlatform"
+	| "chUaPlatformVersion"
+	| "chUaWow64"
+	| "computePressure"
+	| "crossOriginIsolated"
+	| "directSockets"
+	| "displayCapture"
+	| "encryptedMedia"
+	| "executionWhileNotRendered"
+	| "executionWhileOutOfViewport"
+	| "fullscreen"
+	| "geolocation"
+	| "gyroscope"
+	| "hid"
+	| "identityCredentialsGet"
+	| "idleDetection"
+	| "keyboardMap"
+	| "magnetometer"
+	| "microphone"
+	| "midi"
+	| "navigationOverride"
+	| "payment"
+	| "pictureInPicture"
+	| "publickeyCredentialsGet"
+	| "screenWakeLock"
+	| "serial"
+	| "storageAccess"
+	| "syncXhr"
+	| "usb"
+	| "webShare"
+	| "windowManagement"
+	| "xrSpatialTracking";
+
+/**
+ * These features have been proposed, but the definitions have not yet been integrated into their respective specs.
+ */
+type ProposedFeatures =
+	| "clipboardRead"
+	| "clipboardWrite"
+	| "gemepad"
+	| "sharedAutofill"
+	| "speakerSelection";
+
+/**
+ * These features generally have an explainer only, but may be available for experimentation by web developers.
+ */
+type ExperimentalFeatures =
+	| "allScreensCapture"
+	| "browsingTopics"
+	| "capturedSurfaceControl"
+	| "conversionMeasurement"
+	| "digitalCredentialsGet"
+	| "focusWithoutUserActivation"
+	| "joinAdInterestGroup"
+	| "localFonts"
+	| "runAdAuction"
+	| "smartCard"
+	| "syncScript"
+	| "trustTokenRedemption"
+	| "unload"
+	| "verticalScroll";
+
+export interface SecureHeadersVariables {
+	secureHeadersNonce?: string;
+}
+
+type ContentSecurityPolicyOptionValue = Array<string>;
+
+interface ContentSecurityPolicyOptions {
+	defaultSrc?: ContentSecurityPolicyOptionValue;
+	baseUri?: ContentSecurityPolicyOptionValue;
+	childSrc?: ContentSecurityPolicyOptionValue;
+	connectSrc?: ContentSecurityPolicyOptionValue;
+	fontSrc?: ContentSecurityPolicyOptionValue;
+	formAction?: ContentSecurityPolicyOptionValue;
+	frameAncestors?: ContentSecurityPolicyOptionValue;
+	frameSrc?: ContentSecurityPolicyOptionValue;
+	imgSrc?: ContentSecurityPolicyOptionValue;
+	manifestSrc?: ContentSecurityPolicyOptionValue;
+	mediaSrc?: ContentSecurityPolicyOptionValue;
+	objectSrc?: ContentSecurityPolicyOptionValue;
+	reportTo?: string;
+	sandbox?: ContentSecurityPolicyOptionValue;
+	scriptSrc?: ContentSecurityPolicyOptionValue;
+	scriptSrcAttr?: ContentSecurityPolicyOptionValue;
+	scriptSrcElem?: ContentSecurityPolicyOptionValue;
+	styleSrc?: ContentSecurityPolicyOptionValue;
+	styleSrcAttr?: ContentSecurityPolicyOptionValue;
+	styleSrcElem?: ContentSecurityPolicyOptionValue;
+	upgradeInsecureRequests?: ContentSecurityPolicyOptionValue;
+	workerSrc?: ContentSecurityPolicyOptionValue;
+}
+
+interface ReportToOptions {
+	group: string;
+	max_age: number;
+	endpoints: Array<ReportToEndpoint>;
+}
+
+interface ReportToEndpoint {
+	url: string;
+}
+
+interface ReportingEndpointOptions {
+	name: string;
+	url: string;
+}
+
+type PermissionsPolicyValue = "*" | "self" | "src" | "none" | (string & {});
+
+type PermissionsPolicyOptions = Partial<
+	Record<PermissionsPolicyDirective, Array<PermissionsPolicyValue> | boolean>
+>;
+
+type overridableHeader = boolean | string;
+
+type HeadersMap = {
+	[key in keyof unstable_createSecureHeadersMiddleware.SecureHeadersOptions]: [
+		string,
+		string,
+	];
+};
+
+let HEADERS_MAP: HeadersMap = {
+	crossOriginEmbedderPolicy: ["Cross-Origin-Embedder-Policy", "require-corp"],
+	crossOriginResourcePolicy: ["Cross-Origin-Resource-Policy", "same-origin"],
+	crossOriginOpenerPolicy: ["Cross-Origin-Opener-Policy", "same-origin"],
+	originAgentCluster: ["Origin-Agent-Cluster", "?1"],
+	referrerPolicy: ["Referrer-Policy", "no-referrer"],
+	strictTransportSecurity: [
+		"Strict-Transport-Security",
+		"max-age=15552000; includeSubDomains",
+	],
+	xContentTypeOptions: ["X-Content-Type-Options", "nosniff"],
+	xDnsPrefetchControl: ["X-DNS-Prefetch-Control", "off"],
+	xDownloadOptions: ["X-Download-Options", "noopen"],
+	xFrameOptions: ["X-Frame-Options", "SAMEORIGIN"],
+	xPermittedCrossDomainPolicies: ["X-Permitted-Cross-Domain-Policies", "none"],
+	xXssProtection: ["X-XSS-Protection", "0"],
+};
+
+let DEFAULT_OPTIONS: unstable_createSecureHeadersMiddleware.SecureHeadersOptions =
+	{
+		crossOriginEmbedderPolicy: false,
+		crossOriginResourcePolicy: true,
+		crossOriginOpenerPolicy: true,
+		originAgentCluster: true,
+		referrerPolicy: true,
+		strictTransportSecurity: true,
+		xContentTypeOptions: true,
+		xDnsPrefetchControl: true,
+		xDownloadOptions: true,
+		xFrameOptions: true,
+		xPermittedCrossDomainPolicies: true,
+		xXssProtection: true,
+		removePoweredBy: true,
+		permissionsPolicy: {},
+	};
+
+function getFilteredHeaders(
+	options: unstable_createSecureHeadersMiddleware.SecureHeadersOptions,
+): Array<[string, string]> {
+	return Object.entries(HEADERS_MAP)
+		.filter(
+			([key]) =>
+				options[
+					key as keyof unstable_createSecureHeadersMiddleware.SecureHeadersOptions
+				],
+		)
+		.map(([key, defaultValue]) => {
+			let overrideValue =
+				options[
+					key as keyof unstable_createSecureHeadersMiddleware.SecureHeadersOptions
+				];
+			return typeof overrideValue === "string"
+				? [defaultValue[0], overrideValue]
+				: defaultValue;
+		});
+}
+
+function getCSPDirectives(
+	contentSecurityPolicy: ContentSecurityPolicyOptions,
+): string {
+	let resultValues: Array<string> = [];
+
+	for (let [directive, value] of Object.entries(contentSecurityPolicy)) {
+		let valueArray = Array.isArray(value) ? value : [value];
+		resultValues.push(
+			directive.replace(/[A-Z]+(?![a-z])|[A-Z]/g, (match, offset) =>
+				offset ? `-${match.toLowerCase()}` : match.toLowerCase(),
+			),
+			...valueArray.flatMap((value) => [" ", value]),
+			"; ",
+		);
+	}
+	resultValues.pop();
+
+	return resultValues.join("");
+}
+
+function getPermissionsPolicyDirectives(
+	policy: PermissionsPolicyOptions,
+): string {
+	return Object.entries(policy)
+		.map(([directive, value]) => {
+			let kebabDirective = camelToKebab(directive);
+
+			if (typeof value === "boolean") {
+				return `${kebabDirective}=${value ? "*" : "none"}`;
+			}
+
+			if (Array.isArray(value)) {
+				if (value.length === 0) {
+					return `${kebabDirective}=()`;
+				}
+				if (value.length === 1 && (value[0] === "*" || value[0] === "none")) {
+					return `${kebabDirective}=${value[0]}`;
+				}
+				let allowlist = value.map((item) =>
+					["self", "src"].includes(item) ? item : `"${item}"`,
+				);
+				return `${kebabDirective}=(${allowlist.join(" ")})`;
+			}
+
+			return "";
+		})
+		.filter(Boolean)
+		.join(", ");
+}
+
+function camelToKebab(str: string): string {
+	return str.replace(/([a-z\d])([A-Z])/g, "$1-$2").toLowerCase();
+}
+
+function getReportingEndpoints(
+	reportingEndpoints: unstable_createSecureHeadersMiddleware.SecureHeadersOptions["reportingEndpoints"] = [],
+): string {
+	return reportingEndpoints
+		.map((endpoint) => `${endpoint.name}="${endpoint.url}"`)
+		.join(", ");
+}
+
+function getReportToOptions(
+	reportTo: unstable_createSecureHeadersMiddleware.SecureHeadersOptions["reportTo"] = [],
+): string {
+	return reportTo.map((option) => JSON.stringify(option)).join(", ");
+}
+
+function setHeaders(response: Response, headersToSet: Array<[string, string]>) {
+	for (let [header, value] of headersToSet) {
+		response.headers.set(header, value);
+	}
+}
+
+// This approach is written in MDN.
+// btoa does not support utf-8 characters. So we need a little bit hack.
+export function encodeBase64(buf: ArrayBufferLike): string {
+	let binary = "";
+	let bytes = new Uint8Array(buf);
+	for (let byte of bytes) {
+		binary += String.fromCharCode(byte);
+	}
+	return btoa(binary);
+}


### PR DESCRIPTION
Added an adapted version of the [hono Secure headers middleware](https://hono.dev/docs/middleware/builtin/secure-headers#supported-options).