### PR TITLE
Deprecate useDebounceFetcher and useDebounceSubmit hooks

### DIFF
--- a/src/react/use-debounce-fetcher.ts
+++ b/src/react/use-debounce-fetcher.ts
@@ -34,6 +34,10 @@ type DebouncedFetcher<Data = unknown> = Omit<
 	"submit"
 > & { submit: DebounceSubmitFunction };
 
+/**
+ * @deprecated Debounce at the route level instead of the component level.
+ * @see https://sergiodxa.com/tutorials/debounce-loaders-and-actions-in-react-router
+ */
 export function useDebounceFetcher<Data>(
 	opts?: Parameters<typeof useFetcher>[0],
 ) {

--- a/src/react/use-debounce-submit.ts
+++ b/src/react/use-debounce-submit.ts
@@ -4,6 +4,10 @@ import { useSubmit } from "react-router";
 
 type SubmitTarget = Parameters<SubmitFunction>["0"];
 
+/**
+ * @deprecated Debounce at the route level instead of the component level.
+ * @see https://sergiodxa.com/tutorials/debounce-loaders-and-actions-in-react-router
+ */
 export function useDebounceSubmit() {
 	let timeoutRef = useRef<Timer | undefined>(null);
 


### PR DESCRIPTION
Mark the `useDebounceFetcher` and `useDebounceSubmit` hooks as deprecated, recommending the use of debouncing at the route level instead.