### PR TITLE
Add Honeypot middleware for spam protection in forms

### DIFF
--- a/src/server/middleware/honeypot.test.ts
+++ b/src/server/middleware/honeypot.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, mock, test } from "bun:test";
+import { redirect, unstable_RouterContextProvider } from "react-router";
+import { unstable_createHoneypotMiddleware } from "./honeypot";
+import { runMiddleware } from "./test-helper";
+
+describe(unstable_createHoneypotMiddleware.name, () => {
+	test("can get the Honeypot input props", async () => {
+		let [, getInputProps] = unstable_createHoneypotMiddleware();
+		let props = await getInputProps();
+
+		expect(props).toEqual({
+			nameFieldName: "name__confirm",
+			validFromFieldName: "from__confirm",
+			encryptedValidFrom: expect.any(String),
+		});
+	});
+
+	test("if the request has no body the middleware does nothing", async () => {
+		let [middleware] = unstable_createHoneypotMiddleware();
+
+		let request = new Request("https://remix.utils");
+
+		let response = await runMiddleware(middleware, {
+			request,
+			next() {
+				return Response.json(null);
+			},
+		});
+
+		expect(response.json()).resolves.toBeNull();
+	});
+
+	test("if the request is not a form submission the middleware does nothing", async () => {
+		let [middleware] = unstable_createHoneypotMiddleware();
+		let request = new Request("https://remix.utils", {
+			method: "POST",
+			body: JSON.stringify({}),
+			headers: { "Content-Type": "application/json" },
+		});
+		let response = await runMiddleware(middleware, {
+			request,
+			next() {
+				return Response.json(null);
+			},
+		});
+
+		expect(response.json()).resolves.toBeNull();
+	});
+
+	test("if the request is x-www-form-urlencoded the spam check runs", async () => {
+		let [middleware, getInputProps] = unstable_createHoneypotMiddleware();
+		let inputProps = await getInputProps();
+
+		let body = new URLSearchParams();
+		body.set(inputProps.nameFieldName, "");
+		if (inputProps.validFromFieldName) {
+			body.set(inputProps.validFromFieldName, inputProps.encryptedValidFrom);
+		}
+
+		let request = new Request("https://remix.utils", {
+			method: "POST",
+			body,
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		});
+
+		let response = await runMiddleware(middleware, {
+			request,
+			next() {
+				return Response.json(null);
+			},
+		});
+
+		expect(response.json()).resolves.toBeNull();
+	});
+
+	test("if the request is multipart/form-data the spam check runs", async () => {
+		let [middleware, getInputProps] = unstable_createHoneypotMiddleware();
+		let inputProps = await getInputProps();
+
+		let body = new FormData();
+		body.set(inputProps.nameFieldName, "");
+		if (inputProps.validFromFieldName) {
+			body.set(inputProps.validFromFieldName, inputProps.encryptedValidFrom);
+		}
+
+		let request = new Request("https://remix.utils", { method: "POST", body });
+
+		let response = await runMiddleware(middleware, {
+			request,
+			next() {
+				return Response.json(null);
+			},
+		});
+
+		expect(response.json()).resolves.toBeNull();
+	});
+
+	test("if the request is spam the middleware runs the onSpam helper", async () => {
+		let onSpam = mock().mockImplementation(() => redirect("/"));
+		let next = mock().mockImplementation(() => Response.json(null));
+
+		let [middleware, getInputProps] = unstable_createHoneypotMiddleware({
+			onSpam,
+		});
+
+		let inputProps = await getInputProps();
+
+		let body = new URLSearchParams();
+		body.set(inputProps.nameFieldName, "spam");
+		if (inputProps.validFromFieldName) {
+			body.set(inputProps.validFromFieldName, inputProps.encryptedValidFrom);
+		}
+
+		let request = new Request("https://remix.utils", {
+			method: "POST",
+			body,
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		});
+		let response = await runMiddleware(middleware, { request, next });
+
+		expect(response).toEqual(redirect("/"));
+		expect(onSpam).toHaveBeenCalledTimes(1);
+		expect(next).not.toHaveBeenCalled();
+	});
+});

--- a/src/server/middleware/honeypot.ts
+++ b/src/server/middleware/honeypot.ts
@@ -1,0 +1,63 @@
+import type { unstable_MiddlewareFunction } from "react-router";
+import type { HoneypotConfig, HoneypotInputProps } from "../honeypot.js";
+import { Honeypot, SpamError } from "../honeypot.js";
+import type { unstable_MiddlewareGetter } from "./utils.js";
+
+export function unstable_createHoneypotMiddleware({
+	onSpam,
+	...options
+}: unstable_createHoneypotMiddleware.Options = {}): unstable_createHoneypotMiddleware.ReturnType {
+	let honeypot = new Honeypot(options);
+
+	return [
+		async function middleware({ request }, next) {
+			// If there's no body, we can skip the honeypot check (e.g. GET requests)
+			if (request.body === null) return await next();
+			// If the request is not a form submission, we can skip the honeypot check
+			// (e.g. JSON or other types of requests)
+			if (!isFormData(request)) return await next();
+
+			try {
+				let formData = await request.clone().formData();
+				await honeypot.check(formData);
+			} catch (error) {
+				// If the error is a SpamError, we can handle it here and return a
+				// custom response if provided.
+				// Otherwise, we throw the error to be handled by the next middleware
+				// or the error boundary.
+				// This allows us to customize the response for spam errors while still
+				// allowing other errors to propagate normally.
+				if (error instanceof SpamError && onSpam) return onSpam(error);
+				throw error;
+			}
+
+			return await next();
+		},
+
+		function getInputProps() {
+			return honeypot.getInputProps();
+		},
+	];
+
+	// Check if the request is a form submission by checking the content-type
+	// This is needed because the Honeypot class only accepts FormData and we want
+	// to prevent unnecessarily parsing of the request body for other types of
+	// requests.
+	function isFormData(request: Request) {
+		let contentType = request.headers.get("content-type") ?? "";
+		if (contentType.includes("multipart/form-data")) return true;
+		if (contentType.includes("application/x-www-form-urlencoded")) return true;
+		return false;
+	}
+}
+
+export namespace unstable_createHoneypotMiddleware {
+	export interface Options extends HoneypotConfig {
+		onSpam?(error: SpamError): Response;
+	}
+
+	export type ReturnType = [
+		unstable_MiddlewareFunction<Response>,
+		() => Promise<HoneypotInputProps>,
+	];
+}


### PR DESCRIPTION
Introduce a Honeypot middleware to enhance spam protection for public forms.

This middleware validates form submissions and allows for custom handling of spam requests, improving overall form security.