### PR TITLE
Detect client IP behind Azure Front Door with getClientIPAddress

### DIFF
--- a/src/server/get-client-id-address.test.ts
+++ b/src/server/get-client-id-address.test.ts
@@ -5,6 +5,7 @@ const VALID_IP = "192.168.0.1";
 const INVALID_IP = "abc.def.ghi.jkl";
 
 const headerNames = [
+	"X-Azure-ClientIP" /** Azure Front Door */,
 	"X-Client-IP",
 	"X-Forwarded-For",
 	"HTTP-X-Forwarded-For",

--- a/src/server/get-client-ip-address.ts
+++ b/src/server/get-client-ip-address.ts
@@ -6,6 +6,7 @@ import { getHeaders } from "./get-headers.js";
  * determine the client's IP address.
  */
 const headerNames = Object.freeze([
+	"X-Azure-ClientIP" /** Azure Front Door */,
 	"X-Client-IP",
 	"X-Forwarded-For",
 	"HTTP-X-Forwarded-For",


### PR DESCRIPTION
Added the `X-Azure-ClientIP` header above `X-Client-IP` because `X-Client-IP` gets populated with an AFD IP instead of the real client IP.

In this example, the client IP address is 10.0.0.5. Before this PR, `getClientIPAddress` incorrectly returns 172.16.0.10.

#### Example request headers when behind Azure Front Door:

```
Headers: {
  'client-ip': '172.16.0.10:49828',
  'x-azure-clientip': '10.0.0.5',
  'x-client-ip': '172.16.0.10',
  'x-forwarded-for': '10.0.0.5, 192.168.1.20, 172.16.0.10:49828'
}
```

(The real IPs have been replaced with private IPs for demonstrative purposes.)