### PR TITLE
Refactor singleton middleware and improve documentation

### DIFF
--- a/src/server/middleware/batcher.ts
+++ b/src/server/middleware/batcher.ts
@@ -8,7 +8,8 @@ import { unstable_createSingletonMiddleware } from "./singleton.js";
  */
 export function unstable_createBatcherMiddleware() {
 	return unstable_createSingletonMiddleware({
-		Class: Batcher,
-		arguments: [],
+		instantiator: () => new Batcher(),
 	});
 }
+
+export type { Batcher };


### PR DESCRIPTION
Refactor the singleton middleware to utilize an instantiator function for instance creation. Update documentation for singleton, batcher, and context storage middleware to clarify usage and provide examples for better understanding.