### PR TITLE
Add rolling cookie middleware to prolong cookie expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2905,6 +2905,39 @@ export const [corsMiddleware] = unstable_createCorsMiddleware({
 
 The [accepted `options`](#options) are the same as those accepted by the `cors` util.
 
+#### Rolling Cookie Middleware
+
+> [!NOTE]
+> This depends on `zod`, and React Router.
+
+The rolling cookie middleware allows you to prolong the expiration of a cookie by updating the expiration date on every request.
+
+First, create a rolling cookie middleware instance:
+
+```ts
+import { unstable_createRollingCookieMiddleware } from "remix-utils/middleware/rolling-cookie";
+
+// This must be a Cookie or TypedCookie instance
+import { cookie } from "~/cookies";
+
+export const [rollingCookieMiddleware] = unstable_createRollingCookieMiddleware(
+  { cookie }
+);
+```
+
+Then, add the `rollingCookieMiddleware` to the `unstable_middleware` array in your `app/root.tsx` file.
+
+```ts
+import { rollingCookieMiddleware } from "~/middleware/rolling-cookie.server";
+
+export const unstable_middleware = [rollingCookieMiddleware];
+```
+
+Now, every request will have the cookie updated with a new expiration date.
+
+> [!NOTE]
+> If you set the same cookie in your own loaders or actions, the middleware will detect this and do nothing, so you can use the middleware and set the cookie in your own code without worrying about it.
+
 ## Author
 
 - [Sergio Xalambrí](https://sergiodxa.com)

--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
 			"types": "./build/server/middleware/request-id.d.ts",
 			"default": "./build/server/middleware/request-id.js"
 		},
+		"./middleware/rolling-cookie": {
+			"types": "./build/server/middleware/rolling-cookie.d.ts",
+			"default": "./build/server/middleware/rolling-cookie.js"
+		},
 		"./middleware/secure-headers": {
 			"types": "./build/server/middleware/secure-headers.d.ts",
 			"default": "./build/server/middleware/secure-headers.js"

--- a/src/server/middleware/rolling-cookie.test.ts
+++ b/src/server/middleware/rolling-cookie.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { createCookie } from "react-router";
+import { unstable_createRollingCookieMiddleware } from "./rolling-cookie";
+import { runMiddleware } from "./test-helper";
+
+const cookie = createCookie("name", { maxAge: 60 * 60 * 24 });
+
+describe(unstable_createRollingCookieMiddleware.name, () => {
+	test("if the request has no cookie the middleware does nothing", async () => {
+		let [middleware] = unstable_createRollingCookieMiddleware({ cookie });
+		let response = await runMiddleware(middleware);
+		expect(response.headers.getAll("set-cookie")).toEqual([]);
+	});
+
+	test("if the request has a cookie, the middleware rolls it", async () => {
+		let [middleware] = unstable_createRollingCookieMiddleware({ cookie });
+
+		let request = new Request("https://remix.utils", {
+			headers: { Cookie: await cookie.serialize("value from request") },
+		});
+
+		let response = await runMiddleware(middleware, { request });
+
+		expect(response.headers.get("set-cookie")).toBe(
+			await cookie.serialize("value from request"),
+		);
+	});
+
+	test("if the response already sets the cookie, the middleware does nothing", async () => {
+		let [middleware] = unstable_createRollingCookieMiddleware({ cookie });
+
+		let request = new Request("https://remix.utils", {
+			headers: { Cookie: await cookie.serialize("value from request") },
+		});
+
+		let response = await runMiddleware(middleware, {
+			request,
+			async next() {
+				return new Response(null, {
+					headers: {
+						"set-cookie": await cookie.serialize("value from response"),
+					},
+				});
+			},
+		});
+
+		expect(response.headers.get("set-cookie")).toBe(
+			await cookie.serialize("value from response"),
+		);
+	});
+});

--- a/src/server/middleware/rolling-cookie.ts
+++ b/src/server/middleware/rolling-cookie.ts
@@ -1,0 +1,62 @@
+import type { Cookie, unstable_MiddlewareFunction } from "react-router";
+import { rollingCookie } from "../rolling-cookie.js";
+
+/**
+ * The rolling cookie middleware allows you to prolong the expiration of a
+ * cookie by updating the expiration date on every request.
+ *
+ * First, create a rolling cookie middleware instance:
+ *
+ * ```ts
+ * import { unstable_createRollingCookieMiddleware } from "remix-utils/middleware/rolling-cookie";
+ *
+ * // This must be a Cookie or TypedCookie instance
+ * import { cookie } from "~/cookies";
+ *
+ * export const [rollingCookieMiddleware] = unstable_createRollingCookieMiddleware(
+ *   { cookie }
+ * );
+ * ```
+ *
+ * Then, add the `rollingCookieMiddleware` to the `unstable_middleware` array in your `app/root.tsx` file.
+ *
+ * ```ts
+ * import { rollingCookieMiddleware } from "~/middleware/rolling-cookie.server";
+ *
+ * export const unstable_middleware = [rollingCookieMiddleware];
+ * ```
+ *
+ * Now, every request will have the cookie updated with a new expiration date.
+ *
+ * If you set the same cookie in your own loaders or actions, the middleware
+ * will detect this and do nothing, so you can use the middleware and set the
+ * cookie in your own code without worrying about it.
+ * @param options Options for the middleware
+ * @param options.cookie The cookie to use for rolling
+ * @returns A middleware function that keeps the cookie alive
+ */
+export function unstable_createRollingCookieMiddleware(
+	options: unstable_createRollingCookieMiddleware.Options,
+): unstable_createRollingCookieMiddleware.ReturnType {
+	return [
+		async ({ request }, next) => {
+			let response = await next();
+			await rollingCookie(options.cookie, request, response.headers);
+			return response;
+		},
+	];
+}
+
+export namespace unstable_createRollingCookieMiddleware {
+	export interface Options {
+		/**
+		 * The cookie to keep alive.
+		 * This should be a valid cookie object.
+		 * @see https://reactrouter.com/api/utils/createCookie
+		 * @see https://reactrouter.com/explanation/sessions-and-cookies#cookies
+		 */
+		cookie: Cookie;
+	}
+
+	export type ReturnType = [unstable_MiddlewareFunction<Response>];
+}

--- a/src/server/rolling-cookie.ts
+++ b/src/server/rolling-cookie.ts
@@ -2,14 +2,84 @@ import type { Cookie } from "react-router";
 import { z } from "zod";
 import type { TypedCookie } from "./typed-cookie.js";
 
+/**
+ * Rolling cookies allows you to prolong the expiration of a cookie by updating 
+ * the expiration date of every cookie.
+ * 
+ * The `rollingCookie` function is prepared to be used in `entry.server` 
+ * exported function to update the expiration date of a cookie if no loader set 
+ * it.
+ * 
+ * For document request you can use it on the `handleRequest` function:
+ * 
+ * ```ts
+ * import { rollingCookie } from "remix-utils/rolling-cookie";
+ * import { sessionCookie } from "~/session.server";
+ * 
+ * export default function handleRequest(
+ *   request: Request,
+ *   responseStatusCode: number,
+ *   responseHeaders: Headers,
+ *   remixContext: EntryContext
+ * ) {
+ *   await rollingCookie(sessionCookie, request, responseHeaders);
+ * 
+ *   return isbot(request.headers.get("user-agent"))
+ *     ? handleBotRequest(
+ *         request,
+ *         responseStatusCode,
+ *         responseHeaders,
+ *         remixContext
+ *       )
+ *     : handleBrowserRequest(
+ *         request,
+ *         responseStatusCode,
+ *         responseHeaders,
+ *         remixContext
+ *       );
+ * }
+ * ```
+ * 
+ * And for data request you can do it on the `handleDataRequest` function:
+
+ * ```ts
+ * import { rollingCookie } from "remix-utils/rolling-cookie";
+ *
+ * export let handleDataRequest: HandleDataRequestFunction = async (
+ *   response: Response,
+ *   { request }
+ * ) => {
+ *   let cookieValue = await sessionCookie.parse(
+ *     responseHeaders.get("set-cookie")
+ *   );
+ *   if (!cookieValue) {
+ *     cookieValue = await sessionCookie.parse(request.headers.get("cookie"));
+ *     responseHeaders.append(
+ *       "Set-Cookie",
+ *       await sessionCookie.serialize(cookieValue)
+ *     );
+ *   }
+ * 
+ *   return response;
+ * };
+ * ```
+ * 
+ * @param cookie The cookie to keep alive
+ * @param request The request object
+ * @param responseHeaders The response headers object
+ * @returns A promise that resolves when the cookie has been set in the response
+ * @see https://sergiodxa.com/articles/add-rolling-sessions-to-remix
+ */
 export async function rollingCookie<Schema extends z.ZodTypeAny>(
 	cookie: Cookie | TypedCookie<Schema>,
 	request: Request,
 	responseHeaders: Headers,
 ) {
-	let value = await cookie.parse(responseHeaders.get("Set-Cookie"));
-	if (value !== null) return;
-	value = await cookie.parse(request.headers.get("Cookie"));
-	if (!value) return;
-	responseHeaders.append("Set-Cookie", await cookie.serialize(value));
+	const requestCookie = await cookie.parse(request.headers.get("Cookie"));
+	if (!requestCookie) return;
+
+	const responseCookie = await cookie.parse(responseHeaders.get("Set-Cookie"));
+	if (responseCookie !== null) return;
+
+	responseHeaders.append("Set-Cookie", await cookie.serialize(requestCookie));
 }


### PR DESCRIPTION
Introduce a middleware that updates the expiration date of a cookie on every request, ensuring it remains valid. Update documentation to guide users on implementing the middleware.