### PR TITLE
Upgrade minimal required React Router version to 8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ npm add @edgefirst-dev/batcher @edgefirst-dev/jwt @edgefirst-dev/server-timing @
 
 React and React Router packages should be already installed in your project.
 
+> [!IMPORTANT]
+> Remix Utils requires **React Router v8**, which itself requires **React ≥19.2.7** and **Node ≥22.22.0**. If your app is still on React Router v7, stay on Remix Utils 9.x.
+
 ## Upgrade from Remix Utils v6
 
 Check the [v6 to v7 upgrade guide](./docs/v6-to-v7.md).

--- a/bun.lock
+++ b/bun.lock
@@ -28,9 +28,9 @@
         "msw": "^2.12.10",
         "oxfmt": "^0.37.0",
         "oxlint": "^1.52.0",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "react-router": "^7.13.1",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router": "^8.0.0",
         "shadcn": "^4.0.3",
         "ts-node": "^10.9.2",
         "typedoc": "^0.28.17",
@@ -47,8 +47,8 @@
         "@standard-schema/spec": "^1.0.0",
         "intl-parse-accept-language": "^1.0.0",
         "is-ip": "^5.0.1",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-router": "^7.0.0",
+        "react": ">=19.2.7",
+        "react-router": "^8.0.0",
       },
       "optionalPeers": [
         "@edgefirst-dev/batcher",
@@ -453,6 +453,8 @@
 
     "cookie": ["cookie@1.0.2", "", {}, "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="],
 
+    "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
+
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
@@ -837,13 +839,13 @@
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
-    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
+    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
-    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
-    "react-router": ["react-router@7.13.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA=="],
+    "react-router": ["react-router@8.0.0", "", { "dependencies": { "cookie-es": "^3.1.1" }, "peerDependencies": { "react": ">=19.2.7", "react-dom": ">=19.2.7" }, "optionalPeers": ["react-dom"] }, "sha512-AyS7LUn9M3g2/IBJDJNpWqElaQjPVBHGgMsdLGee6B2JLwP9STSpRwN8N4SauOeFTb0X5ZN0wxa1Iek78jF8Iw=="],
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
@@ -876,8 +878,6 @@
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "set-cookie-parser": ["set-cookie-parser@2.7.1", "", {}, "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 

--- a/package.json
+++ b/package.json
@@ -288,9 +288,9 @@
 		"msw": "^2.12.10",
 		"oxfmt": "^0.37.0",
 		"oxlint": "^1.52.0",
-		"react": "^19.2.4",
-		"react-dom": "^19.2.4",
-		"react-router": "^7.13.1",
+		"react": "^19.2.7",
+		"react-dom": "^19.2.7",
+		"react-router": "^8.0.0",
 		"shadcn": "^4.0.3",
 		"ts-node": "^10.9.2",
 		"typedoc": "^0.28.17",
@@ -307,8 +307,8 @@
 		"@standard-schema/spec": "^1.0.0",
 		"intl-parse-accept-language": "^1.0.0",
 		"is-ip": "^5.0.1",
-		"react": "^18.0.0 || ^19.0.0",
-		"react-router": "^7.0.0"
+		"react": ">=19.2.7",
+		"react-router": "^8.0.0"
 	},
 	"peerDependenciesMeta": {
 		"@edgefirst-dev/batcher": {
@@ -343,6 +343,6 @@
 		}
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=22.22.0"
 	}
 }

--- a/src/react/external-scripts.tsx
+++ b/src/react/external-scripts.tsx
@@ -281,10 +281,10 @@ export function useExternalScripts() {
 
 			let result = scripts({
 				id: match.id,
-				data: match.data,
+				data: match.loaderData,
 				params: match.params,
 				location,
-				parentsData: matches.slice(0, index).map((match) => match.data),
+				parentsData: matches.slice(0, index).map((match) => match.loaderData),
 				matches,
 			});
 

--- a/src/react/use-locales.ts
+++ b/src/react/use-locales.ts
@@ -69,9 +69,9 @@ export function useLocales(): Locales {
 
 	// check if rootMatch exists and has data
 	if (!rootMatch) return undefined;
-	if (!rootMatch.data) return undefined;
+	if (!rootMatch.loaderData) return undefined;
 
-	let { data } = rootMatch;
+	let { loaderData: data } = rootMatch;
 
 	// check if data is an object and has locales
 	if (typeof data !== "object") return undefined;

--- a/src/react/use-should-hydrate.ts
+++ b/src/react/use-should-hydrate.ts
@@ -89,7 +89,7 @@ export function useShouldHydrate() {
 	return useMatches().some((match) => {
 		if (!match.handle) return false;
 
-		let { handle, data } = match;
+		let { handle, loaderData: data } = match;
 
 		// handle must be an object to continue
 		if (typeof handle !== "object") return false;

--- a/src/server/middleware/test-helper.ts
+++ b/src/server/middleware/test-helper.ts
@@ -32,17 +32,21 @@ export async function runMiddleware<T = Response>(
 		request = new Request("https://remix.utils"),
 		context = new RouterContextProvider(),
 		params = {},
-		unstable_pattern = "",
 		next = defaultNext,
 	}: {
 		request?: Request;
 		params?: Params;
 		context?: Readonly<RouterContextProvider>;
-		unstable_pattern?: string;
 		next?: () => Promise<T>;
 	} = {},
 ) {
-	return (await middleware({ request, params, context, unstable_pattern }, next)) as T;
+	// React Router's middleware args type carries fields the middlewares under
+	// test never read (`pattern`, `url`, …). Assert the minimal shape we need
+	// rather than constructing a full DataFunctionArgs.
+	return (await middleware(
+		{ request, params, context } as Parameters<typeof middleware>[0],
+		next,
+	)) as T;
 }
 
 export async function catchResponse<T>(promise: Promise<T>) {

--- a/src/server/preload-route-assets.test.ts
+++ b/src/server/preload-route-assets.test.ts
@@ -62,10 +62,7 @@ describe(preloadRouteAssets, () => {
 				links: undefined,
 			},
 		},
-		future: {
-			v8_middleware: true,
-			unstable_subResourceIntegrity: true,
-		},
+		future: {},
 		staticHandlerContext: {
 			actionData: {},
 			actionHeaders: {},


### PR DESCRIPTION
## Summary

A **pure React Router v8** bump that drops v7 support entirely.

> **Alternative approach:** #597 keeps **both** React Router v7 (from 7.13.1) and v8 working, as an additive, non-breaking (minor) change. This PR is the simpler "v8-only" path and is a **breaking** (major) change. The two are mutually exclusive — pick whichever matches the project's support policy.

## Changes

- **`package.json`** — aligned with React Router v8's own requirements:
  - peer deps → `react-router: "^8.0.0"`, `react: ">=19.2.7"` (drops React 18; `>=` matches React Router v8's own React peer)
  - `engines.node` → `>=22.22.0`
  - dev deps → `react-router@8`, `react`/`react-dom@^19.2.7`
- **`src/react/external-scripts.tsx`, `use-locales.ts`, `use-should-hydrate.ts`** — `match.data` → `match.loaderData`. v8 removed the deprecated `data` alias on the objects returned by `useMatches()`.
- **`src/server/middleware/test-helper.ts`** — assert the minimal middleware args shape; v8's `DataFunctionArgs` requires `pattern`, `url`, … that no middleware under test reads.
- **`src/server/preload-route-assets.test.ts`** — drop the `future.*` flags v8 removed (`v8_middleware`, `unstable_subResourceIntegrity`).

The source middleware utilities and the public API are otherwise unchanged — they already used React Router's (now-default in v8) middleware API.

## Verification

|                          | typecheck | build | test        | attw | lint | format |
| ------------------------ | --------- | ----- | ----------- | ---- | ---- | ------ |
| RR v8.0.0 / React 19.2.7 | ✅        | ✅    | ✅ 400 pass | ✅   | ✅   | ✅     |

## Note on versioning

Dropping v7 and raising the React/Node floors is a breaking change, so this should be a **major** bump. I left the `version` field untouched since releases look to be cut by your automation.
